### PR TITLE
Setup CI/CD for Cloud Run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Build and Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  SERVICE_NAME: ai-tool-navigator
+  REGION: us-central1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # Required for authenticating with Google Cloud
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Downcase Repo Name
+        run: echo "REPO_LOWER=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.REPO_LOWER }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE_NAME }}
+          region: ${{ env.REGION }}
+          image: ghcr.io/${{ env.REPO_LOWER }}:latest
+          flags: '--allow-unauthenticated'
+          env_vars: |
+            NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# Use a lightweight Node.js image
+FROM public.ecr.aws/docker/library/node:18-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN npm run build
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+# set hostname to localhost
+ENV HOSTNAME="0.0.0.0"
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -29,8 +29,47 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## CI/CD Setup for Google Cloud Run
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+This repository is configured with a GitHub Actions workflow to automatically build and deploy the Next.js application to Google Cloud Run.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+### Prerequisites
+
+1.  **Google Cloud Platform (GCP) Project**:
+    -   Ensure you have a GCP project.
+    -   Enable the **Cloud Run API**.
+
+2.  **Service Account**:
+    -   Create a Service Account in your GCP project.
+    -   Grant the following roles to the Service Account:
+        -   **Cloud Run Developer**: To deploy services.
+        -   **Service Account User**: To act as the service account.
+    -   Create and download a JSON key key for this Service Account.
+
+3.  **GitHub Packages (ghcr.io)**:
+    -   The workflow pushes the Docker image to GitHub Container Registry.
+    -   **Important**: Ensure your GitHub Package visibility is set to **Public** so that Cloud Run can pull the image without additional authentication configuration. Alternatively, you can configure Cloud Run with image pull secrets for private packages.
+
+### GitHub Secrets Configuration
+
+Go to your repository's **Settings** > **Secrets and variables** > **Actions** and add the following secrets:
+
+-   `GCP_PROJECT_ID`: Your Google Cloud Project ID (e.g., `Hashimoto620`).
+-   `GCP_SA_KEY`: The content of the JSON key file you downloaded for the Service Account.
+
+### Database Setup (Supabase / PostgreSQL)
+
+This setup assumes you are using a PostgreSQL-compatible database (e.g., Supabase Free Tier).
+
+1.  Obtain your `DATABASE_URL` from your provider (e.g., Supabase).
+2.  Add the `DATABASE_URL` environment variable to your Cloud Run service:
+    -   You can do this via the Google Cloud Console UI when editing the service.
+    -   Or add it to the `env_vars` section in `.github/workflows/deploy.yml` (not recommended for sensitive values).
+    -   **Best Practice**: Store `DATABASE_URL` in Google Secret Manager and reference it in Cloud Run.
+
+### Usage
+
+Every push to the `main` branch will trigger the workflow:
+1.  Build the Docker image.
+2.  Push the image to `ghcr.io/<your-username>/<repo-name>`.
+3.  Deploy the new image to Cloud Run service `ai-tool-navigator`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
This change sets up a complete CI/CD pipeline for deploying the Next.js application to Google Cloud Run. It uses GitHub Container Registry (ghcr.io) to store Docker images and deploys them to Cloud Run. It also includes comprehensive documentation in the README on how to configure the necessary secrets and infrastructure.

---
*PR created automatically by Jules for task [8525542447936367683](https://jules.google.com/task/8525542447936367683) started by @yuga-hashimoto*