### PR TITLE
Add custom 404 page

### DIFF
--- a/dev_server_2.log
+++ b/dev_server_2.log
@@ -1,0 +1,12 @@
+
+> ai-tool-navigator@0.1.0 dev
+> next dev -p 3002
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3002
+- Network:       http://192.168.0.2:3002
+
+✓ Starting...
+⨯ Unable to acquire lock at /app/.next/dev/lock, is another instance of next dev running?
+  Suggestion: If you intended to restart next dev, terminate the other process, and then try again.
+[?25h

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import './globals.css';
+
+export const metadata = {
+  title: '404 - Page Not Found',
+};
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background text-foreground antialiased">
+      <div className="container px-4 text-center">
+        <div className="mb-4 text-9xl font-bold tracking-tighter text-muted-foreground/30">
+          404
+        </div>
+        <h1 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
+          Page Not Found
+        </h1>
+        <p className="mx-auto mb-8 max-w-md text-muted-foreground">
+          Sorry, we couldn't find the page you're looking for. It might have been moved or doesn't exist.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-8 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+        >
+          Return Home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a custom 404 page to `src/app/not-found.tsx`. The page features a clean, centered design with a large "404" indicator, a descriptive error message, and a button to return to the home page. It is styled using the project's existing Tailwind CSS variables for consistency. The implementation handles global 404 errors and correctly integrates with Next.js's default layout behavior when no root layout is present. Verification was performed using Playwright to ensure correct rendering and link functionality.

---
*PR created automatically by Jules for task [4904849866369537356](https://jules.google.com/task/4904849866369537356) started by @yuga-hashimoto*