### PR TITLE
Implement random related tools selection

### DIFF
--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -99,8 +99,15 @@ export function getToolSlugs() {
 
 export function getRelatedTools(currentTool: ToolMetadata, limit: number = 3, locale: string = 'en'): ToolMetadata[] {
   const allTools = getAllTools(locale);
-  return allTools
-    .filter((tool) => tool.category === currentTool.category && tool.slug !== currentTool.slug)
-    .sort((a, b) => b.rating - a.rating)
-    .slice(0, limit);
+  const candidates = allTools.filter(
+    (tool) => tool.category === currentTool.category && tool.slug !== currentTool.slug
+  );
+
+  // Shuffle the candidates array
+  for (let i = candidates.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
+  }
+
+  return candidates.slice(0, limit);
 }


### PR DESCRIPTION
Implemented random selection for the 'Related Tools' section on the tool details page. Previously, related tools were sorted by rating. Now, 3 random tools from the same category are displayed, excluding the current tool. This was achieved by modifying `getRelatedTools` in `src/lib/tools.ts` to use a Fisher-Yates shuffle. Verified with manual script and Playwright.

---
*PR created automatically by Jules for task [7651240421696850766](https://jules.google.com/task/7651240421696850766) started by @yuga-hashimoto*