### PR TITLE
Add dynamic OpenGraph and Twitter tags to tool pages

### DIFF
--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -25,9 +25,22 @@ export async function generateMetadata(
     }
   }
 
+  const title = `${tool.metadata.title} - AI Tool Navigator`;
+  const description = tool.metadata.description;
+
   return {
-    title: `${tool.metadata.title} - AI Tool Navigator`,
-    description: tool.metadata.description,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
   }
 }
 


### PR DESCRIPTION
Updated `src/app/[locale]/tools/[slug]/page.tsx` to include `openGraph` and `twitter` fields in the `generateMetadata` function.
Verified using a standalone script `verify_metadata_standalone.ts` which confirmed the presence and correctness of the tags.

---
*PR created automatically by Jules for task [7804743154072530776](https://jules.google.com/task/7804743154072530776) started by @yuga-hashimoto*