### PR TITLE
Add "Submit Your Tool" CTA button to navigation bar

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -19,8 +19,8 @@ export function Navigation() {
               <Link href="/blog" className="text-sm font-medium text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white transition-colors">
                 Blog
               </Link>
-              <Link href="/submit" className="text-sm font-medium text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white transition-colors">
-                Submit Tool
+              <Link href="/submit" className="text-sm font-medium bg-blue-600 text-white px-4 py-2 rounded-full hover:bg-blue-500 transition-colors shadow-sm ml-4">
+                Submit Your Tool
               </Link>
             </div>
           </div>
@@ -35,8 +35,8 @@ export function Navigation() {
               <Link href="/blog" className="text-sm font-medium text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white transition-colors">
                 Blog
               </Link>
-              <Link href="/submit" className="text-sm font-medium text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white transition-colors">
-                Submit Tool
+              <Link href="/submit" className="text-sm font-medium bg-blue-600 text-white px-4 py-2 rounded-full hover:bg-blue-500 transition-colors shadow-sm">
+                Submit Your Tool
               </Link>
            </div>
         </div>


### PR DESCRIPTION
This change updates the main navigation bar to feature a prominent "Submit Your Tool" call-to-action button, linking to the `/submit` page. The button is styled with a blue background to stand out. The `/submit` page was confirmed to already exist and be functional, so no placeholder was needed.

---
*PR created automatically by Jules for task [7786979750480586335](https://jules.google.com/task/7786979750480586335) started by @yuga-hashimoto*