### PR TITLE
Add Sponsored Tools section to homepage

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -40,7 +40,12 @@
       "compare": "Compare",
       "selected": "Selected",
       "readMore": "Read more",
-      "featured": "Featured"
+      "featured": "Featured",
+      "sponsored": "Sponsored"
+  },
+  "SponsoredTools": {
+      "title": "Sponsored Tools",
+      "sponsored": "Sponsored"
   },
   "FeaturedTools": {
       "title": "Featured Tools",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -40,7 +40,12 @@
       "compare": "比較",
       "selected": "選択済み",
       "readMore": "続きを読む",
-      "featured": "注目"
+      "featured": "注目",
+      "sponsored": "スポンサー"
+  },
+  "SponsoredTools": {
+      "title": "スポンサーツール",
+      "sponsored": "スポンサー"
   },
   "FeaturedTools": {
       "title": "注目のツール",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import { getAllTools } from "@/lib/tools";
 import { ToolGrid } from "@/components/ToolGrid";
 import { ToolCard } from "@/components/ToolCard";
 import { FeaturedTools } from "@/components/FeaturedTools";
+import { SponsoredTools } from "@/components/SponsoredTools";
 import { Link } from "@/i18n/routing";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from 'next-intl/server';
@@ -33,6 +34,9 @@ export default async function Home({
             {t('description')}
           </p>
         </div>
+
+        {/* Sponsored Tools Section */}
+        <SponsoredTools tools={tools} />
 
         {/* Featured Comparison Banner */}
         <div className="mb-16">

--- a/src/components/SponsoredTools.tsx
+++ b/src/components/SponsoredTools.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ToolMetadata } from '@/lib/tools';
+import { ToolCard } from '@/components/ToolCard';
+import { useTranslations } from 'next-intl';
+import { Zap } from 'lucide-react';
+
+interface SponsoredToolsProps {
+  tools: ToolMetadata[];
+}
+
+export function SponsoredTools({ tools }: SponsoredToolsProps) {
+  const sponsoredTools = tools.filter((tool) => tool.sponsored);
+  const t = useTranslations('SponsoredTools');
+
+  if (sponsoredTools.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-16">
+      <div className="flex items-center gap-2 mb-6">
+        <Zap className="h-6 w-6 text-yellow-500 fill-yellow-500" />
+        <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-white">
+          {t('title')}
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {sponsoredTools.map((tool) => (
+          <div key={tool.slug} className="flex flex-col h-full">
+            <ToolCard tool={tool} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -22,7 +22,11 @@ export function ToolCard({ tool }: { tool: ToolMetadata }) {
   return (
     <div className={cn(
         "group relative flex flex-col justify-between overflow-hidden rounded-2xl border bg-white p-6 shadow-sm transition-all hover:shadow-md dark:bg-zinc-900/50 dark:hover:bg-zinc-900",
-        isSelected ? "border-blue-500 ring-1 ring-blue-500 dark:border-blue-400 dark:ring-blue-400" : "border-zinc-200 dark:border-zinc-800"
+        isSelected
+          ? "border-blue-500 ring-1 ring-blue-500 dark:border-blue-400 dark:ring-blue-400"
+          : tool.sponsored
+          ? "border-amber-400 ring-1 ring-amber-400/50 dark:border-amber-500 dark:ring-amber-500/50 bg-amber-50/30 dark:bg-amber-900/10"
+          : "border-zinc-200 dark:border-zinc-800"
     )}>
       <div>
         <div className="flex items-center justify-between">
@@ -30,6 +34,11 @@ export function ToolCard({ tool }: { tool: ToolMetadata }) {
                 <span className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
                 {tool.category}
                 </span>
+                {tool.sponsored && (
+                  <span className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-bold text-amber-800 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-400/10 dark:text-amber-500 dark:ring-amber-400/20 uppercase tracking-wide">
+                    {t('sponsored')}
+                  </span>
+                )}
                 {tool.featured && (
                 <span className="inline-flex items-center rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-400/10 dark:text-amber-500 dark:ring-amber-400/20">
                     {t('featured')}

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -14,6 +14,7 @@ export interface ToolMetadata {
   cons?: string[];
   affiliate_link: string;
   promoted?: boolean;
+  sponsored?: boolean;
   last_updated?: string;
   verified?: boolean;
   discount?: string;


### PR DESCRIPTION
This PR adds a dedicated "Sponsored Tools" section to the top of the homepage. Tools can be marked as sponsored by adding `sponsored: true` to their frontmatter. Sponsored tools are displayed with a distinct visual style (amber border and badge) to distinguish them from the main list. The section automatically hides if no tools are marked as sponsored.

---
*PR created automatically by Jules for task [14059299868543886162](https://jules.google.com/task/14059299868543886162) started by @yuga-hashimoto*