### PR TITLE
Create 'Best AI Coding Assistants 2026' Top 10 List (JA)

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getPostBySlug, getPostSlugs } from "@/lib/posts";
+import { getPostBySlug, getAllPosts } from "@/lib/posts";
 import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -7,11 +7,11 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Metadata } from "next";
 
 export async function generateStaticParams() {
-  const slugs = getPostSlugs();
   const params = [];
   for (const locale of routing.locales) {
-    for (const slugObj of slugs) {
-      params.push({ locale, slug: slugObj.slug });
+    const posts = getAllPosts(locale);
+    for (const post of posts) {
+      params.push({ locale, slug: post.slug });
     }
   }
   return params;


### PR DESCRIPTION
Added 'Best AI Coding Assistants 2026' Top 10 List (JA) to 'content/posts/ja/best-ai-coding-assistants-2026.md'. Also updated 'src/app/[locale]/blog/[slug]/page.tsx' to correctly use 'getAllPosts(locale)' for generating static params, ensuring locale-specific posts are found.

---
*PR created automatically by Jules for task [8063997819778647567](https://jules.google.com/task/8063997819778647567) started by @yuga-hashimoto*