### PR TITLE
feat: enhance SoftwareApplication schema for better SEO

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,5 +1,16 @@
 import { Tool } from "@/lib/tools";
 
+const APPLICATION_CATEGORY_MAP: Record<string, string> = {
+  "Video Generation": "Multimedia",
+  "Writing": "Productivity",
+  "Copywriting": "Business",
+  "Code": "Developer",
+  "Coding": "Developer",
+  "Coding Agent": "Developer",
+  "LLM": "Productivity",
+  "Search": "Utilities",
+};
+
 export function generateToolSchema(tool: Tool) {
   const { metadata } = tool;
 
@@ -9,7 +20,7 @@ export function generateToolSchema(tool: Tool) {
     "@type": "SoftwareApplication",
     name: metadata.title,
     description: metadata.description,
-    applicationCategory: metadata.category,
+    applicationCategory: APPLICATION_CATEGORY_MAP[metadata.category] || metadata.category || "Application",
     operatingSystem: "Web",
   };
 
@@ -17,13 +28,21 @@ export function generateToolSchema(tool: Tool) {
     schema.dateModified = metadata.last_updated;
   }
 
+  if (metadata.pros && metadata.pros.length > 0) {
+    schema.featureList = metadata.pros;
+  }
+
   if (metadata.affiliate_link) {
-    schema.offers = {
+    const offer: any = {
       "@type": "Offer",
       url: metadata.affiliate_link,
       price: "0",
       priceCurrency: "USD",
     };
+    if (metadata.discount) {
+      offer.description = metadata.discount;
+    }
+    schema.offers = offer;
   }
 
   if (metadata.rating) {


### PR DESCRIPTION
This PR enhances the `SoftwareApplication` structured data generation in `src/lib/schema.ts` to improve SEO.

Key changes:
- Introduced `APPLICATION_CATEGORY_MAP` to map `metadata.category` (e.g. "Coding", "Video Generation") to standard Schema.org application categories and types (e.g. "Developer", "Multimedia").
- Added `featureList` property to the schema, populated from the tool's `pros` list.
- Enhanced the `offers` object to include a `description` field derived from `metadata.discount` (e.g. "20% OFF"), providing more context for the offer.
- Ensured fallback to "SoftwareApplication" type and original category string if no mapping exists.

These changes help search engines better understand the category and features of the tools listed, potentially leading to richer search results (snippets).

---
*PR created automatically by Jules for task [1189054761565675636](https://jules.google.com/task/1189054761565675636) started by @yuga-hashimoto*