### PR TITLE
feat(seo): optimize meta titles and descriptions for category pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -99,12 +99,12 @@
     "close": "Close"
   },
   "CategoryPage": {
-    "video_title": "Video Generation Tools",
-    "video_description": "Create stunning videos with AI.",
-    "writing_title": "Writing & Copywriting Tools",
-    "writing_description": "Generate high-quality content in seconds.",
-    "coding_title": "Coding Assistants & Agents",
-    "coding_description": "Build software faster with AI.",
+    "video_title": "Top AI Video Generator Tools & Software (2025)",
+    "video_description": "Discover the best AI video generation tools to create professional videos in minutes. Compare features, pricing, and reviews of top video AI software.",
+    "writing_title": "Best AI Writing Assistants & Copywriting Tools",
+    "writing_description": "Boost your content creation with top-rated AI writing assistants. Find the best tools for copywriting, blogging, and creative writing.",
+    "coding_title": "Best AI Coding Assistants & Developer Tools",
+    "coding_description": "Accelerate your development workflow with the best AI coding assistants. Compare code generation, debugging, and refactoring tools.",
     "noTools": "No tools found in this category."
   },
   "BlogPage": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -99,12 +99,12 @@
     "close": "閉じる"
   },
   "CategoryPage": {
-    "video_title": "動画生成ツール",
-    "video_description": "AIで素晴らしい動画を作成しましょう。",
-    "writing_title": "ライティング＆コピーライティングツール",
-    "writing_description": "数秒で高品質なコンテンツを生成します。",
-    "coding_title": "コーディングアシスタント＆エージェント",
-    "coding_description": "AIでソフトウェア開発を加速させましょう。",
+    "video_title": "おすすめAI動画生成ツール・ソフト (2025年版)",
+    "video_description": "プロ品質の動画を数分で作成できる最高のAI動画生成ツールを見つけましょう。機能、価格、レビューを比較。",
+    "writing_title": "最高のAIライティングアシスタント＆コピーライティングツール",
+    "writing_description": "評価の高いAIライティングアシスタントでコンテンツ作成を効率化。コピーライティング、ブログ、クリエイティブな執筆に最適なツールを探す。",
+    "coding_title": "おすすめAIコーディングアシスタント＆開発ツール",
+    "coding_description": "最高のAIコーディングアシスタントで開発ワークフローを加速。コード生成、デバッグ、リファクタリングツールを比較。",
     "noTools": "このカテゴリーのツールは見つかりませんでした。"
   },
   "BlogPage": {

--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -30,10 +30,21 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     
     const title = t(titleKey);
     const description = t(descriptionKey);
+    const fullTitle = `${title} - AI Tool Navigator`;
 
     return {
-        title: `${title} - AI Tool Navigator`,
+        title: fullTitle,
         description: description,
+        openGraph: {
+            title: fullTitle,
+            description: description,
+            type: 'website',
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: fullTitle,
+            description: description,
+        },
     }
 }
 


### PR DESCRIPTION
This PR optimizes the SEO for category pages by updating the meta titles and descriptions to be more descriptive and keyword-rich. It also adds Open Graph and Twitter metadata tags to improve social sharing. The changes cover both English and Japanese locales for the `video`, `writing`, and `coding` categories.

---
*PR created automatically by Jules for task [14518550909296702979](https://jules.google.com/task/14518550909296702979) started by @yuga-hashimoto*