### PR TITLE
Add Pros & Cons section to tool detail pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -72,6 +72,7 @@
     "tryThisTool": "Try this Tool",
     "pros": "Pros",
     "cons": "Cons",
+    "prosConsTitle": "Pros & Cons",
     "relatedTools": "Related Tools",
     "toolNotFound": "Tool Not Found"
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -72,6 +72,7 @@
     "tryThisTool": "ツールを試す",
     "pros": "長所",
     "cons": "短所",
+    "prosConsTitle": "長所と短所",
     "relatedTools": "関連ツール",
     "toolNotFound": "ツールが見つかりません"
   },

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -1,12 +1,13 @@
 import { getToolBySlug, getToolSlugs, getRelatedTools } from "@/lib/tools";
 import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
-import { Star, CheckCircle2, XCircle, ExternalLink, ArrowLeft, BadgeCheck, Calendar } from "lucide-react";
+import { Star, ExternalLink, ArrowLeft, BadgeCheck, Calendar } from "lucide-react";
 import { Link } from "@/i18n/routing";
 import { Metadata } from "next";
 import { ToolCard } from "@/components/ToolCard";
 import { getTranslations } from "next-intl/server";
 import { generateToolSchema } from "@/lib/schema";
+import { ProsConsSection } from "@/components/ProsConsSection";
 
 export async function generateStaticParams() {
   const slugs = getToolSlugs();
@@ -123,36 +124,15 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                     </a>
                 </div>
 
-                <div className="mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2">
-                    {metadata.pros && metadata.pros.length > 0 && (
-                        <div className="rounded-2xl bg-green-50/50 p-6 ring-1 ring-green-600/10 dark:bg-green-500/5 dark:ring-green-500/20">
-                            <h3 className="flex items-center text-sm font-semibold text-green-700 dark:text-green-400 mb-4">
-                                <CheckCircle2 className="mr-2 h-5 w-5" /> {t('pros')}
-                            </h3>
-                            <ul className="space-y-3">
-                                {metadata.pros.map((pro: string, idx: number) => (
-                                    <li key={idx} className="flex items-start text-sm text-zinc-700 dark:text-zinc-300">
-                                        <span className="mr-2">•</span> {pro}
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    )}
-                    {metadata.cons && metadata.cons.length > 0 && (
-                        <div className="rounded-2xl bg-red-50/50 p-6 ring-1 ring-red-600/10 dark:bg-red-500/5 dark:ring-red-500/20">
-                            <h3 className="flex items-center text-sm font-semibold text-red-700 dark:text-red-400 mb-4">
-                                <XCircle className="mr-2 h-5 w-5" /> {t('cons')}
-                            </h3>
-                            <ul className="space-y-3">
-                                {metadata.cons.map((con: string, idx: number) => (
-                                    <li key={idx} className="flex items-start text-sm text-zinc-700 dark:text-zinc-300">
-                                        <span className="mr-2">•</span> {con}
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    )}
-                </div>
+                <ProsConsSection
+                    pros={metadata.pros}
+                    cons={metadata.cons}
+                    labels={{
+                        title: t('prosConsTitle'),
+                        pros: t('pros'),
+                        cons: t('cons'),
+                    }}
+                />
 
                 <div className="mt-12 prose prose-zinc dark:prose-invert max-w-none">
                     <ReactMarkdown>{content}</ReactMarkdown>

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -1,0 +1,58 @@
+
+import { CheckCircle2, XCircle } from "lucide-react";
+
+interface ProsConsSectionProps {
+  pros?: string[];
+  cons?: string[];
+  labels: {
+    pros: string;
+    cons: string;
+    title?: string;
+  };
+}
+
+export function ProsConsSection({ pros, cons, labels }: ProsConsSectionProps) {
+  if ((!pros || pros.length === 0) && (!cons || cons.length === 0)) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8">
+      {labels.title && (
+        <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-white mb-6">
+            {labels.title}
+        </h2>
+      )}
+      <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
+        {pros && pros.length > 0 && (
+          <div className="rounded-2xl bg-green-50/50 p-6 ring-1 ring-green-600/10 dark:bg-green-500/5 dark:ring-green-500/20">
+            <h3 className="flex items-center text-sm font-semibold text-green-700 dark:text-green-400 mb-4">
+              <CheckCircle2 className="mr-2 h-5 w-5" /> {labels.pros}
+            </h3>
+            <ul className="space-y-3">
+              {pros.map((pro, idx) => (
+                <li key={idx} className="flex items-start text-sm text-zinc-700 dark:text-zinc-300">
+                  <span className="mr-2">•</span> {pro}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {cons && cons.length > 0 && (
+          <div className="rounded-2xl bg-red-50/50 p-6 ring-1 ring-red-600/10 dark:bg-red-500/5 dark:ring-red-500/20">
+            <h3 className="flex items-center text-sm font-semibold text-red-700 dark:text-red-400 mb-4">
+              <XCircle className="mr-2 h-5 w-5" /> {labels.cons}
+            </h3>
+            <ul className="space-y-3">
+              {cons.map((con, idx) => (
+                <li key={idx} className="flex items-start text-sm text-zinc-700 dark:text-zinc-300">
+                  <span className="mr-2">•</span> {con}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces a dedicated "Pros & Cons" section with a localized title to the tool detail pages. It refactors the existing inline pros/cons rendering logic into a reusable `ProsConsSection` component and adds the missing section header "Pros & Cons" (localized as "長所と短所" in Japanese) to improve the page structure and readability. Visual verification was performed using Playwright.

---
*PR created automatically by Jules for task [13011722150440480361](https://jules.google.com/task/13011722150440480361) started by @yuga-hashimoto*