### PR TITLE
Update sitemap generation for i18n support

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,16 +2,14 @@ import { MetadataRoute } from 'next'
 import { getAllTools } from '@/lib/tools'
 import { getAllPosts } from '@/lib/posts'
 import { CATEGORY_MAPPINGS } from '@/lib/categories'
+import { routing } from '@/i18n/routing'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://ai-tool-navigator.vercel.app'
-  const locales = ['en', 'ja']
+  const locales = routing.locales
   
   // Static pages that exist for each locale
-  // Note: 'tools' index is just a redirect usually or handled via category, but structure says /tools/[slug]. 
-  // There is no /tools page based on file structure (only [slug]). 
-  // However, there is /deals, /compare, etc.
-  const staticPages = ['', 'deals', 'compare', 'privacy', 'terms', 'submit', 'advertise', 'sponsor']
+  const staticPages = ['', 'deals', 'compare', 'privacy', 'terms', 'submit', 'advertise', 'sponsor', 'blog']
 
   // 1. Static Pages
   const staticEntries = locales.flatMap((locale) =>
@@ -44,28 +42,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }))
   )
 
-  // 4. Blog Index
-  const blogIndexEntry = {
-    url: `${baseUrl}/blog`,
-    lastModified: new Date(),
-    changeFrequency: 'daily' as const,
-    priority: 0.8,
-  }
-
-  // 5. Blog Posts
-  const posts = getAllPosts()
-  const postEntries = posts.map((post) => ({
-    url: `${baseUrl}/blog/${post.slug}`,
-    lastModified: new Date(post.date),
-    changeFrequency: 'monthly' as const,
-    priority: 0.7,
-  }))
+  // 4. Blog Posts
+  const postEntries = locales.flatMap((locale) => {
+    const posts = getAllPosts(locale)
+    return posts.map((post) => ({
+      url: `${baseUrl}/${locale}/blog/${post.slug}`,
+      lastModified: new Date(post.date),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    }))
+  })
 
   return [
     ...staticEntries,
     ...toolEntries,
     ...categoryEntries,
-    blogIndexEntry,
     ...postEntries,
   ]
 }


### PR DESCRIPTION
Updated `src/app/sitemap.ts` to correctly generate a localized sitemap for the application.

Changes include:
- Replaced hardcoded locales with `routing.locales`.
- Added localized static pages (including `blog`, `compare`, `deals`, etc.).
- Iterated over all locales to generate entries for tools, categories, and blog posts.
- Localized blog post URLs are now correctly generated as `/${locale}/blog/${slug}`.
- Removed the unlocalized blog index entry.

Verified the output using a temporary script to ensure correct URL structure and no duplicates.

---
*PR created automatically by Jules for task [11228751921869450095](https://jules.google.com/task/11228751921869450095) started by @yuga-hashimoto*