### PR TITLE
Add AI Tool of the Week section

### DIFF
--- a/content/tools/en/cursor.md
+++ b/content/tools/en/cursor.md
@@ -5,6 +5,7 @@ category: "Code"
 description: "The AI-first Code Editor built on VS Code."
 rating: 4.7
 promoted: true
+tool_of_the_week: true
 pros:
   - "Seamless VS Code fork"
   - "Excellent codebase indexing"

--- a/content/tools/ja/cursor.md
+++ b/content/tools/ja/cursor.md
@@ -5,6 +5,7 @@ category: 'Code'
 description: 'VS Codeをベースに構築された、AIファーストのコードエディタ。'
 rating: 4.7
 promoted: true
+tool_of_the_week: true
 pros:
   - 'VS Codeからの移行がスムーズ'
   - '優れたコードベースのインデックス作成'

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,18 @@
+
+> ai-tool-navigator@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 2.2s
+○ Compiling /[locale] ...
+ GET /en 200 in 8.0s (compile: 6.6s, proxy.ts: 193ms, render: 1197ms)

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,6 +2,7 @@
   "HomePage": {
     "title": "Premium AI Tool Comparison",
     "description": "Find the perfect AI tool for your needs. Unbiased reviews, pros & cons, and detailed comparisons.",
+    "toolOfTheWeek": "AI Tool of the Week",
     "featuredComparison": "Featured Comparison",
     "editorsChoice": "Editor's Choice",
     "noTools": "No tools found matching your criteria."

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -2,6 +2,7 @@
   "HomePage": {
     "title": "プレミアムAIツール比較",
     "description": "あなたのニーズに最適なAIツールを見つけましょう。公平なレビュー、長所と短所、そして詳細な比較を提供します。",
+    "toolOfTheWeek": "今週のAIツール",
     "featuredComparison": "注目の比較",
     "editorsChoice": "編集部のおすすめ",
     "noTools": "条件に一致するツールは見つかりませんでした。"

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,8 +1,9 @@
-import { getAllTools } from "@/lib/tools";
+import { getAllTools, getToolOfTheWeek } from "@/lib/tools";
 import { ToolGrid } from "@/components/ToolGrid";
 import { ToolCard } from "@/components/ToolCard";
 import { FeaturedTools } from "@/components/FeaturedTools";
 import { SponsoredTools } from "@/components/SponsoredTools";
+import { ToolOfTheWeek } from "@/components/ToolOfTheWeek";
 import { Link } from "@/i18n/routing";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from 'next-intl/server';
@@ -21,6 +22,7 @@ export default async function Home({
   const { locale } = await params;
   const t = await getTranslations('HomePage');
   const tools = getAllTools(locale);
+  const toolOfTheWeek = getToolOfTheWeek(locale);
   const editorsChoiceSlugs = ['speechify', 'mixo', 'copy-ai', 'basedlabs', 'homesage'];
   const editorsChoiceTools = tools.filter(tool => editorsChoiceSlugs.includes(tool.slug));
 
@@ -38,6 +40,9 @@ export default async function Home({
 
         {/* Sponsored Tools Section */}
         <SponsoredTools tools={tools} />
+
+        {/* Tool of the Week Section */}
+        <ToolOfTheWeek tool={toolOfTheWeek} />
 
         {/* Featured Comparison Banner */}
         <div className="mb-16">

--- a/src/components/ToolOfTheWeek.tsx
+++ b/src/components/ToolOfTheWeek.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { ToolMetadata } from '@/lib/tools';
+import { Link } from '@/i18n/routing';
+import { Star, Zap, CheckCircle2, ArrowRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+interface ToolOfTheWeekProps {
+  tool: ToolMetadata | null;
+}
+
+export function ToolOfTheWeek({ tool }: ToolOfTheWeekProps) {
+  const t = useTranslations('HomePage');
+  const tFeatured = useTranslations('FeaturedTools');
+
+  if (!tool) {
+    return null;
+  }
+
+  return (
+    <div className="mb-16">
+      <div className="flex items-center gap-2 mb-6">
+        <Zap className="h-6 w-6 text-purple-500 fill-purple-500" />
+        <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-white">
+          {t('toolOfTheWeek')}
+        </h2>
+      </div>
+
+      <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-purple-500/10 via-pink-500/10 to-orange-500/10 p-[1px] shadow-lg hover:shadow-xl transition-all hover:scale-[1.005]">
+        <div className="relative h-full rounded-[23px] bg-white dark:bg-zinc-950 p-8 md:p-10 flex flex-col md:flex-row gap-8 items-start">
+
+            {/* Background Glow */}
+            <div className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-purple-500/10 blur-3xl group-hover:bg-purple-500/20 transition-colors" />
+            <div className="absolute -left-24 -bottom-24 h-64 w-64 rounded-full bg-orange-500/10 blur-3xl group-hover:bg-orange-500/20 transition-colors" />
+
+            <div className="flex-1 z-10">
+                <div className="mb-4">
+                    <span className="inline-flex items-center rounded-md bg-purple-100 px-2.5 py-1 text-sm font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+                        {tool.category}
+                    </span>
+                </div>
+
+                <h3 className="text-3xl md:text-4xl font-extrabold text-zinc-900 dark:text-white mb-4">
+                    <Link href={`/tools/${tool.slug}`} className="hover:underline decoration-purple-500/30 underline-offset-4">
+                        {tool.title}
+                    </Link>
+                </h3>
+
+                <p className="text-lg text-zinc-600 dark:text-zinc-300 mb-6 leading-relaxed max-w-2xl">
+                    {tool.description}
+                </p>
+
+                <div className="flex items-center gap-2 mb-8">
+                     <div className="flex">
+                        {[...Array(5)].map((_, i) => (
+                            <Star
+                                key={i}
+                                className={`h-5 w-5 ${i < Math.floor(tool.rating) ? 'fill-amber-400 text-amber-400' : 'fill-zinc-200 text-zinc-200 dark:fill-zinc-800 dark:text-zinc-800'}`}
+                            />
+                        ))}
+                     </div>
+                     <span className="text-lg font-bold text-zinc-900 dark:text-white ml-1">{tool.rating}</span>
+                </div>
+
+                <div className="flex flex-wrap gap-x-6 gap-y-3 mb-8">
+                    {tool.pros && tool.pros.slice(0, 3).map((pro, idx) => (
+                    <div key={idx} className="flex items-center gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                        <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0" />
+                        <span>{pro}</span>
+                    </div>
+                    ))}
+                </div>
+
+                <Link
+                    href={`/tools/${tool.slug}`}
+                    className="inline-flex items-center justify-center rounded-xl bg-zinc-900 px-6 py-3 text-base font-semibold text-white transition-all hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200 shadow-sm"
+                >
+                    {tFeatured('checkItOut')} <ArrowRight className="ml-2 h-5 w-5" />
+                </Link>
+            </div>
+
+            {/* Visual element or large icon on the right for desktop */}
+            <div className="hidden md:flex flex-col items-center justify-center flex-shrink-0 w-32 h-32 md:w-48 md:h-48 rounded-2xl bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 self-center">
+                 <span className="text-4xl font-bold text-zinc-400 dark:text-zinc-600 uppercase tracking-widest">{tool.title.substring(0, 2)}</span>
+            </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -15,6 +15,7 @@ export interface ToolMetadata {
   affiliate_link: string;
   promoted?: boolean;
   sponsored?: boolean;
+  tool_of_the_week?: boolean;
   last_updated?: string;
   verified?: boolean;
   discount?: string;
@@ -84,6 +85,11 @@ export function getToolBySlug(slug: string, locale: string = 'en'): Tool | null 
     } as ToolMetadata,
     content: matterResult.content,
   };
+}
+
+export function getToolOfTheWeek(locale: string = 'en'): ToolMetadata | null {
+  const tools = getAllTools(locale);
+  return tools.find((tool) => tool.tool_of_the_week) || null;
 }
 
 export function getToolSlugs() {


### PR DESCRIPTION
This PR adds a new "AI Tool of the Week" section to the homepage. It introduces a `tool_of_the_week` frontmatter field for tools, updates the `Cursor` tool to be the featured tool, and renders a prominent card on the homepage. Translation support for English and Japanese is included.

---
*PR created automatically by Jules for task [8889124116423270458](https://jules.google.com/task/8889124116423270458) started by @yuga-hashimoto*