### PR TITLE
Implement Related Articles on Review Pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -74,6 +74,7 @@
     "cons": "Cons",
     "prosConsTitle": "Pros & Cons",
     "relatedTools": "Related Tools",
+    "relatedArticles": "Related Articles",
     "toolNotFound": "Tool Not Found"
   },
   "CompareBar": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -74,6 +74,7 @@
     "cons": "短所",
     "prosConsTitle": "長所と短所",
     "relatedTools": "関連ツール",
+    "relatedArticles": "関連記事",
     "toolNotFound": "ツールが見つかりません"
   },
   "CompareBar": {

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,7 +1,7 @@
 import { getAllPosts } from "@/lib/posts";
-import { Link } from "@/i18n/routing";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { ArticleCard } from "@/components/ArticleCard";
 
 export const metadata: Metadata = {
   title: "Blog - AI Tool Navigator",
@@ -30,40 +30,7 @@ export default async function BlogPage({
         </div>
         <div className="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
           {posts.map((post) => (
-            <article key={post.slug} className="flex flex-col items-start justify-between">
-              <div className="relative w-full">
-                {/* Image placeholder could go here */}
-                 <div className="flex items-center gap-x-4 text-xs">
-                  <time dateTime={post.date} className="text-zinc-500 dark:text-zinc-400">
-                    {new Date(post.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-                  </time>
-                  {post.tags && post.tags.length > 0 && (
-                      <span className="relative z-10 rounded-full bg-zinc-100 px-3 py-1.5 font-medium text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700">
-                        {post.tags[0]}
-                      </span>
-                  )}
-                </div>
-                <div className="group relative">
-                  <h3 className="mt-3 text-lg font-semibold leading-6 text-zinc-900 group-hover:text-zinc-600 dark:text-zinc-100 dark:group-hover:text-zinc-300">
-                    <Link href={`/blog/${post.slug}`}>
-                      <span className="absolute inset-0" />
-                      {post.title}
-                    </Link>
-                  </h3>
-                  <p className="mt-5 line-clamp-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-                    {post.excerpt}
-                  </p>
-                </div>
-                <div className="relative mt-8 flex items-center gap-x-4">
-                  <div className="text-sm leading-6">
-                    <p className="font-semibold text-zinc-900 dark:text-zinc-100">
-                      <span className="absolute inset-0" />
-                      {post.author}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </article>
+            <ArticleCard key={post.slug} post={post} locale={locale} />
           ))}
         </div>
       </div>

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -1,10 +1,12 @@
 import { getToolBySlug, getToolSlugs, getRelatedTools } from "@/lib/tools";
+import { getRelatedPosts } from "@/lib/posts";
 import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import { Star, ExternalLink, ArrowLeft, BadgeCheck, Calendar } from "lucide-react";
 import { Link } from "@/i18n/routing";
 import { Metadata } from "next";
 import { ToolCard } from "@/components/ToolCard";
+import { ArticleCard } from "@/components/ArticleCard";
 import { getTranslations } from "next-intl/server";
 import { generateToolSchema } from "@/lib/schema";
 import { ProsConsSection } from "@/components/ProsConsSection";
@@ -57,6 +59,7 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
   const { metadata, content } = tool;
   const { verified, last_updated } = metadata;
   const relatedTools = getRelatedTools(metadata, 3, locale);
+  const relatedPosts = getRelatedPosts(metadata, 3, locale);
   const jsonLd = generateToolSchema(tool);
 
   return (
@@ -148,6 +151,19 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                 <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
                     {relatedTools.map((relatedTool) => (
                         <ToolCard key={relatedTool.slug} tool={relatedTool} />
+                    ))}
+                </div>
+            </div>
+        )}
+
+        {relatedPosts.length > 0 && (
+            <div className="mt-16">
+                <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-white mb-6">
+                    {t('relatedArticles')}
+                </h2>
+                <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                    {relatedPosts.map((post) => (
+                        <ArticleCard key={post.slug} post={post} locale={locale} />
                     ))}
                 </div>
             </div>

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,0 +1,52 @@
+import { PostMetadata } from "@/lib/posts";
+import { Link } from "@/i18n/routing";
+
+interface ArticleCardProps {
+  post: PostMetadata;
+  locale: string;
+}
+
+export function ArticleCard({ post, locale }: ArticleCardProps) {
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  };
+  const dateLocale = locale === 'ja' ? 'ja-JP' : 'en-US';
+
+  return (
+    <article className="flex flex-col items-start justify-between">
+      <div className="relative w-full">
+         <div className="flex items-center gap-x-4 text-xs">
+          <time dateTime={post.date} className="text-zinc-500 dark:text-zinc-400">
+            {new Date(post.date).toLocaleDateString(dateLocale, dateOptions)}
+          </time>
+          {post.tags && post.tags.length > 0 && (
+              <span className="relative z-10 rounded-full bg-zinc-100 px-3 py-1.5 font-medium text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700">
+                {post.tags[0]}
+              </span>
+          )}
+        </div>
+        <div className="group relative">
+          <h3 className="mt-3 text-lg font-semibold leading-6 text-zinc-900 group-hover:text-zinc-600 dark:text-zinc-100 dark:group-hover:text-zinc-300">
+            <Link href={`/blog/${post.slug}`}>
+              <span className="absolute inset-0" />
+              {post.title}
+            </Link>
+          </h3>
+          <p className="mt-5 line-clamp-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+            {post.excerpt}
+          </p>
+        </div>
+        <div className="relative mt-8 flex items-center gap-x-4">
+          <div className="text-sm leading-6">
+            <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+              <span className="absolute inset-0" />
+              {post.author}
+            </p>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import { ToolMetadata } from './tools';
 
 const postsDirectory = path.join(process.cwd(), 'content/posts');
 
@@ -97,4 +98,59 @@ export function getPostSlugs() {
         slug: fileName.replace(/\.md$/, ''),
       };
     });
+}
+
+export function getRelatedPosts(tool: ToolMetadata, limit: number = 3, locale: string = 'en'): PostMetadata[] {
+  const allPosts = getAllPosts(locale);
+
+  if (allPosts.length === 0) {
+    return [];
+  }
+
+  // Calculate scores for each post
+  const scoredPosts = allPosts.map((post) => {
+    let score = 0;
+    const toolCategory = tool.category.toLowerCase();
+    const toolTitle = tool.title.toLowerCase();
+
+    // Check tags
+    if (post.tags) {
+      post.tags.forEach((tag) => {
+        const lowerTag = tag.toLowerCase();
+        // Exact category match or partial match
+        if (lowerTag === toolCategory || toolCategory.includes(lowerTag) || lowerTag.includes(toolCategory)) {
+          score += 3;
+        }
+        // Title match
+        if (toolTitle.includes(lowerTag)) {
+           score += 2;
+        }
+      });
+    }
+
+    // Check post title match
+    if (post.title.toLowerCase().includes(toolCategory)) {
+        score += 1;
+    }
+
+    return { post, score };
+  });
+
+  // Filter posts with score > 0 and sort by score descending
+  let related = scoredPosts
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((item) => item.post);
+
+  // If we don't have enough related posts, fill with recent posts
+  if (related.length < limit) {
+    const usedSlugs = new Set(related.map(p => p.slug));
+    const recent = allPosts
+        .filter(p => !usedSlugs.has(p.slug))
+        // allPosts is already sorted by date
+        .slice(0, limit - related.length);
+    related = [...related, ...recent];
+  }
+
+  return related.slice(0, limit);
 }


### PR DESCRIPTION
Implemented a "Related Articles" section at the bottom of tool review pages.
This section dynamically fetches and displays blog posts that are relevant to the current tool, based on category and tag matching.
It uses a new `ArticleCard` component which is also used in the main Blog page for consistency.
Verified with Playwright and manual script testing.

---
*PR created automatically by Jules for task [1281559812863325467](https://jules.google.com/task/1281559812863325467) started by @yuga-hashimoto*