### PR TITLE
Enhance Footer with Social Links & Copyright

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@/i18n/routing';
 import { useTranslations } from 'next-intl';
+import { Github, Linkedin, Twitter } from 'lucide-react';
 
 export function Footer() {
   const t = useTranslations('Footer');
@@ -7,19 +8,35 @@ export function Footer() {
   return (
     <footer className="bg-zinc-50 dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800">
       <div className="mx-auto max-w-7xl px-6 py-12 md:flex md:items-center md:justify-between lg:px-8">
-        <div className="flex justify-center space-x-6 md:order-2">
-          <Link href="/submit" className="text-zinc-500 hover:text-zinc-400">
-            {t('submit')}
-          </Link>
-          <Link href="/sponsor" className="text-zinc-500 hover:text-zinc-400">
-            {t('sponsorship')}
-          </Link>
-          <Link href="/privacy" className="text-zinc-500 hover:text-zinc-400">
-            {t('privacy')}
-          </Link>
-          <Link href="/terms" className="text-zinc-500 hover:text-zinc-400">
-            {t('terms')}
-          </Link>
+        <div className="flex flex-col items-center md:items-end space-y-4 md:order-2">
+          <div className="flex space-x-6">
+            <a href="#" target="_blank" rel="noopener noreferrer" className="text-zinc-500 hover:text-zinc-400">
+              <span className="sr-only">Twitter</span>
+              <Twitter className="h-5 w-5" />
+            </a>
+            <a href="#" target="_blank" rel="noopener noreferrer" className="text-zinc-500 hover:text-zinc-400">
+              <span className="sr-only">GitHub</span>
+              <Github className="h-5 w-5" />
+            </a>
+            <a href="#" target="_blank" rel="noopener noreferrer" className="text-zinc-500 hover:text-zinc-400">
+              <span className="sr-only">LinkedIn</span>
+              <Linkedin className="h-5 w-5" />
+            </a>
+          </div>
+          <div className="flex space-x-6">
+            <Link href="/submit" className="text-zinc-500 hover:text-zinc-400">
+              {t('submit')}
+            </Link>
+            <Link href="/sponsor" className="text-zinc-500 hover:text-zinc-400">
+              {t('sponsorship')}
+            </Link>
+            <Link href="/privacy" className="text-zinc-500 hover:text-zinc-400">
+              {t('privacy')}
+            </Link>
+            <Link href="/terms" className="text-zinc-500 hover:text-zinc-400">
+              {t('terms')}
+            </Link>
+          </div>
         </div>
         <div className="mt-8 md:order-1 md:mt-0 space-y-2">
           <p className="text-center md:text-left text-xs leading-5 text-zinc-500">


### PR DESCRIPTION
Enhanced the Footer component by adding social media links (Twitter, GitHub, LinkedIn) and improving the layout. The copyright notice remains on the left, while social icons and navigation links are stacked on the right (desktop). Used `lucide-react` for icons and ensured accessibility with screen-reader only text.

---
*PR created automatically by Jules for task [11448378852574362649](https://jules.google.com/task/11448378852574362649) started by @yuga-hashimoto*