### PR TITLE
Fix mobile menu responsive border visibility

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,22 @@
+
+> ai-tool-navigator@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 2.3s
+○ Compiling /[locale] ...
+ GET /en 200 in 8.5s (compile: 7.3s, proxy.ts: 8ms, render: 1204ms)
+ GET /en 200 in 182ms (compile: 88ms, proxy.ts: 36ms, render: 58ms)
+ GET /en 200 in 1442ms (compile: 715ms, proxy.ts: 21ms, render: 706ms)
+ GET /en 200 in 147ms (compile: 54ms, proxy.ts: 9ms, render: 84ms)
+ GET /en 200 in 290ms (compile: 38ms, proxy.ts: 5ms, render: 247ms)

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -64,8 +64,8 @@ export function Navigation({ className }: { className?: string }) {
       {/* Mobile Menu */}
       <div
         className={cn(
-          "md:hidden overflow-hidden transition-all duration-300 ease-in-out border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black",
-          isMenuOpen ? "max-h-screen opacity-100" : "max-h-0 opacity-0"
+          "md:hidden overflow-hidden transition-all duration-300 ease-in-out bg-white dark:bg-black",
+          isMenuOpen ? "max-h-screen opacity-100 border-b border-zinc-200 dark:border-zinc-800" : "max-h-0 opacity-0"
         )}
       >
         <div className="px-6 py-4 space-y-4">


### PR DESCRIPTION
Fixed an issue where the mobile navigation menu displayed a 1px bottom border even when closed.
- Modified `src/components/Navigation.tsx` to apply `border-b` only when `isMenuOpen` is true.
- Verified the fix using a Playwright script to ensure the menu is properly hidden and no visual artifacts remain.
- Confirmed the menu is responsive and functional.

---
*PR created automatically by Jules for task [6245567434871987819](https://jules.google.com/task/6245567434871987819) started by @yuga-hashimoto*