### PR TITLE
feat: Add 'Featured Tools' Carousel to Homepage

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -58,12 +58,17 @@
       "featured": "Featured",
       "sponsored": "Sponsored"
   },
+  "FeaturedCarousel": {
+      "title": "Featured Tools",
+      "viewDeal": "View Deal",
+      "learnMore": "Learn More"
+  },
   "SponsoredTools": {
       "title": "Sponsored Tools",
       "sponsored": "Sponsored"
   },
   "FeaturedTools": {
-      "title": "Featured Tools",
+      "title": "Promoted Tools",
       "promoted": "Promoted",
       "checkItOut": "Check it out"
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -58,12 +58,17 @@
       "featured": "注目",
       "sponsored": "スポンサー"
   },
+  "FeaturedCarousel": {
+      "title": "注目のツール",
+      "viewDeal": "詳細を見る",
+      "learnMore": "もっと詳しく"
+  },
   "SponsoredTools": {
       "title": "スポンサーツール",
       "sponsored": "スポンサー"
   },
   "FeaturedTools": {
-      "title": "注目のツール",
+      "title": "プロモーションツール",
       "promoted": "プロモーション",
       "checkItOut": "チェックする"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@hookform/resolvers": "^5.2.2",
         "@swc/helpers": "^0.5.18",
         "clsx": "^2.1.1",
+        "embla-carousel-autoplay": "^8.6.0",
+        "embla-carousel-react": "^8.6.0",
         "googleapis": "^171.4.0",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.563.0",
@@ -3718,6 +3720,43 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@hookform/resolvers": "^5.2.2",
     "@swc/helpers": "^0.5.18",
     "clsx": "^2.1.1",
+    "embla-carousel-autoplay": "^8.6.0",
+    "embla-carousel-react": "^8.6.0",
     "googleapis": "^171.4.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.563.0",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import { getAllTools, getToolOfTheWeek } from "@/lib/tools";
 import { ToolGrid } from "@/components/ToolGrid";
 import { ToolCard } from "@/components/ToolCard";
 import { FeaturedTools } from "@/components/FeaturedTools";
+import { FeaturedCarousel } from "@/components/FeaturedCarousel";
 import { SponsoredTools } from "@/components/SponsoredTools";
 import { ToolOfTheWeek } from "@/components/ToolOfTheWeek";
 import { Link } from "@/i18n/routing";
@@ -72,6 +73,9 @@ export default async function Home({
             </div>
           </Link>
         </div>
+
+        {/* Featured Tools Carousel */}
+        <FeaturedCarousel tools={tools} />
 
         {/* Featured Tools Section (Promoted) */}
         <FeaturedTools tools={tools} />

--- a/src/components/FeaturedCarousel.tsx
+++ b/src/components/FeaturedCarousel.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from 'react';
+import useEmblaCarousel from 'embla-carousel-react';
+import Autoplay from 'embla-carousel-autoplay';
+import { ToolMetadata } from '@/lib/tools';
+import { Link } from '@/i18n/routing';
+import { Star, ArrowRight, Sparkles } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+interface FeaturedCarouselProps {
+  tools: ToolMetadata[];
+}
+
+export function FeaturedCarousel({ tools }: FeaturedCarouselProps) {
+  const featuredTools = tools.filter((tool) => tool.featured);
+  const t = useTranslations('FeaturedCarousel');
+  const [emblaRef] = useEmblaCarousel({ loop: true, align: 'start' }, [Autoplay({ delay: 5000, stopOnInteraction: false })]);
+
+  if (featuredTools.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-16 relative">
+        <div className="flex items-center gap-2 mb-6">
+            <Sparkles className="h-6 w-6 text-indigo-500 fill-indigo-500" />
+            <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-white">
+                {t('title')}
+            </h2>
+        </div>
+      <div className="overflow-hidden -mx-4 px-4 py-4" ref={emblaRef}>
+        <div className="flex -ml-6">
+          {featuredTools.map((tool, index) => (
+            <div key={tool.slug} className="flex-[0_0_100%] md:flex-[0_0_50%] lg:flex-[0_0_33.333%] min-w-0 pl-6">
+               <Link href={`/tools/${tool.slug}`} className="block h-full group">
+                 <div className="relative h-full overflow-hidden rounded-3xl bg-zinc-900 dark:bg-zinc-800 p-8 shadow-xl transition-all duration-300 hover:shadow-2xl hover:-translate-y-1 border border-zinc-800/50">
+
+                    {/* Background Gradients */}
+                    <div className={`absolute inset-0 opacity-20 bg-gradient-to-br ${
+                        index % 3 === 0 ? 'from-blue-500 via-purple-500 to-pink-500' :
+                        index % 3 === 1 ? 'from-emerald-500 via-teal-500 to-cyan-500' :
+                        'from-orange-500 via-amber-500 to-yellow-500'
+                    }`} />
+
+                    {/* Content */}
+                    <div className="relative z-10 flex flex-col h-full">
+                        <div className="flex items-center justify-between mb-4">
+                            <span className="inline-flex items-center rounded-md bg-white/10 px-2.5 py-1 text-xs font-medium text-white backdrop-blur-sm border border-white/10">
+                                {tool.category}
+                            </span>
+                            <div className="flex items-center gap-1 bg-black/20 px-2 py-1 rounded-full backdrop-blur-sm">
+                                <Star className="h-3.5 w-3.5 fill-yellow-400 text-yellow-400" />
+                                <span className="text-sm font-bold text-white">{tool.rating}</span>
+                            </div>
+                        </div>
+
+                        <h3 className="text-2xl font-bold text-white mb-2 group-hover:text-white/90 transition-colors">
+                            {tool.title}
+                        </h3>
+
+                        <p className="text-zinc-300 text-sm line-clamp-3 mb-6 flex-grow">
+                            {tool.description}
+                        </p>
+
+                        <div className="flex items-center text-sm font-semibold text-white/90 group-hover:text-white mt-auto">
+                            {t('viewDeal')}
+                            <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+                        </div>
+                    </div>
+                 </div>
+               </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -14,6 +14,7 @@ export interface ToolMetadata {
   cons?: string[];
   affiliate_link: string;
   promoted?: boolean;
+  featured?: boolean;
   sponsored?: boolean;
   tool_of_the_week?: boolean;
   last_updated?: string;


### PR DESCRIPTION
- Resolved merge conflict by manually implementing `FeaturedCarousel`.
- Added `embla-carousel-react` and `embla-carousel-autoplay` dependencies.
- Created `FeaturedCarousel` component to display tools marked as `featured: true`.
- Updated `ToolMetadata` interface to include `featured` property.
- Integrated `FeaturedCarousel` into `src/app/[locale]/page.tsx`.
- Renamed the existing "Featured Tools" section (which displays `promoted` tools) to "Promoted Tools" in translations to avoid confusion with the new carousel.
- Verified visual rendering with Playwright script.

---
*PR created automatically by Jules for task [13645863292487957443](https://jules.google.com/task/13645863292487957443) started by @yuga-hashimoto*