### PR TITLE
feat: Add 'Copy Link' Button to Tool Details

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -81,7 +81,9 @@
     "prosConsTitle": "Pros & Cons",
     "relatedTools": "Related Tools",
     "relatedArticles": "Related Articles",
-    "toolNotFound": "Tool Not Found"
+    "toolNotFound": "Tool Not Found",
+    "copyLink": "Copy Link",
+    "copied": "Copied"
   },
   "CompareBar": {
       "selected": "selected",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -81,7 +81,9 @@
     "prosConsTitle": "長所と短所",
     "relatedTools": "関連ツール",
     "relatedArticles": "関連記事",
-    "toolNotFound": "ツールが見つかりません"
+    "toolNotFound": "ツールが見つかりません",
+    "copyLink": "リンクをコピー",
+    "copied": "コピーしました"
   },
   "CompareBar": {
       "selected": "選択済み",

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { ArticleCard } from "@/components/ArticleCard";
 import { getTranslations } from "next-intl/server";
 import { generateToolSchema } from "@/lib/schema";
 import { ProsConsSection } from "@/components/ProsConsSection";
+import { CopyLinkButton } from "@/components/CopyLinkButton";
 
 export async function generateStaticParams() {
   const slugs = getToolSlugs();
@@ -117,14 +118,17 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                             )}
                         </div>
                     </div>
-                    <a
-                        href={metadata.affiliate_link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex w-full sm:w-auto items-center justify-center rounded-full bg-green-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-green-500 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 transition-all transform hover:scale-105"
-                    >
-                        {t('tryThisTool')} <ExternalLink className="ml-2 h-4 w-4" />
-                    </a>
+                    <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
+                        <CopyLinkButton className="w-full sm:w-auto" />
+                        <a
+                            href={metadata.affiliate_link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex w-full sm:w-auto items-center justify-center rounded-full bg-green-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-green-500 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 transition-all transform hover:scale-105"
+                        >
+                            {t('tryThisTool')} <ExternalLink className="ml-2 h-4 w-4" />
+                        </a>
+                    </div>
                 </div>
 
                 <ProsConsSection

--- a/src/components/CopyLinkButton.tsx
+++ b/src/components/CopyLinkButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Link as LinkIcon, Check } from "lucide-react";
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+
+export function CopyLinkButton({ className }: { className?: string }) {
+  const [copied, setCopied] = useState(false);
+  const t = useTranslations("ToolPage");
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy: ", err);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={cn(
+        "inline-flex items-center justify-center rounded-full border px-8 py-4 text-base font-semibold transition-all transform hover:scale-105 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        copied
+          ? "border-green-600 bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400"
+          : "border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700",
+        className
+      )}
+      aria-label={t("copyLink")}
+    >
+      {copied ? (
+        <>
+          {t("copied")} <Check className="ml-2 h-4 w-4" />
+        </>
+      ) : (
+        <>
+          {t("copyLink")} <LinkIcon className="ml-2 h-4 w-4" />
+        </>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
Added a "Copy Link" button to the tool details page. The button is placed next to the "Try This Tool" button and allows users to copy the current page URL to their clipboard. It provides visual feedback ("Copied") upon clicking. Localized strings were added for English and Japanese. verified the feature using a Playwright script.

---
*PR created automatically by Jules for task [14172010260637052320](https://jules.google.com/task/14172010260637052320) started by @yuga-hashimoto*