### PR TITLE
Implement OpenGraph (OG) Meta Tags

### DIFF
--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,108 @@
+import { ImageResponse } from 'next/og';
+import { getPostBySlug } from '@/lib/posts';
+
+export const runtime = 'nodejs';
+
+export const alt = 'AI Tool Navigator Blog';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+  const { slug, locale } = await params;
+  const post = getPostBySlug(slug, locale);
+
+  if (!post) {
+      return new ImageResponse(
+        (
+          <div
+            style={{
+              fontSize: 48,
+              background: 'white',
+              width: '100%',
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            Post not found
+          </div>
+        ),
+        { ...size }
+      );
+  }
+
+  const { metadata } = post;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(to bottom right, #18181b, #09090b)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          fontFamily: 'sans-serif',
+          color: 'white',
+          padding: '80px',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 20,
+            color: '#a1a1aa',
+            marginBottom: 20,
+            textTransform: 'uppercase',
+            letterSpacing: '0.1em',
+          }}
+        >
+          Blog Post
+        </div>
+
+        <div
+          style={{
+            fontSize: 60,
+            fontWeight: 'bold',
+            marginBottom: 40,
+            lineHeight: 1.1,
+            color: 'white',
+            maxWidth: '100%',
+            // simple truncation logic if title is too long (basic handling)
+            display: '-webkit-box',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+          }}
+        >
+          {metadata.title}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '20px' }}>
+          <div style={{ fontSize: 30, color: '#e4e4e7' }}>
+            {metadata.author}
+          </div>
+          <div style={{ fontSize: 30, color: '#52525b' }}>•</div>
+          <div style={{ fontSize: 30, color: '#a1a1aa' }}>
+             {new Date(metadata.date).toLocaleDateString(locale === 'ja' ? 'ja-JP' : 'en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+          </div>
+        </div>
+
+        <div style={{ marginTop: 'auto', display: 'flex', alignItems: 'center', gap: '10px' }}>
+             <div style={{ width: 40, height: 40, background: '#3b82f6', borderRadius: '50%' }} />
+             <div style={{ fontSize: 24, fontWeight: 'bold' }}>AI Tool Navigator</div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -31,9 +31,25 @@ export async function generateMetadata(
     }
   }
 
+  const title = `${post.metadata.title} - AI Tool Navigator Blog`;
+  const description = post.metadata.excerpt;
+
   return {
-    title: `${post.metadata.title} - AI Tool Navigator Blog`,
-    description: post.metadata.excerpt,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'article',
+      publishedTime: post.metadata.date,
+      authors: [post.metadata.author],
+      url: `/${locale}/blog/${slug}`,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
   }
 }
 

--- a/src/app/[locale]/category/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/category/[slug]/opengraph-image.tsx
@@ -1,0 +1,87 @@
+import { ImageResponse } from 'next/og';
+import { getTranslations } from 'next-intl/server';
+import { CATEGORY_MAPPINGS } from '@/lib/categories';
+
+export const runtime = 'nodejs';
+
+export const alt = 'AI Tool Category';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+  const { slug, locale } = await params;
+
+  if (!Object.keys(CATEGORY_MAPPINGS).includes(slug)) {
+      return new ImageResponse(
+        (
+            <div style={{ fontSize: 48, background: 'white', width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                Category Not Found
+            </div>
+        ), { ...size }
+      );
+  }
+
+  const t = await getTranslations({ locale, namespace: 'CategoryPage' });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const title = t(`${slug}_title` as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const description = t(`${slug}_description` as any);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(to bottom right, #18181b, #09090b)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'sans-serif',
+          color: 'white',
+          padding: '40px',
+          textAlign: 'center',
+        }}
+      >
+        <div
+            style={{
+                fontSize: 24,
+                color: '#3b82f6',
+                marginBottom: 20,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+            }}
+        >
+            AI Tool Category
+        </div>
+
+        <div
+          style={{
+            fontSize: 80,
+            fontWeight: 'bold',
+            marginBottom: 30,
+            background: 'linear-gradient(to right, #fff, #94a3b8)',
+            backgroundClip: 'text',
+            color: 'transparent',
+            lineHeight: 1.1,
+          }}
+        >
+          {title}
+        </div>
+
+        <div style={{ fontSize: 32, color: '#e4e4e7', maxWidth: '80%', lineHeight: 1.4 }}>
+          {description}
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -40,6 +40,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
             title: fullTitle,
             description: description,
             type: 'website',
+            url: `/${locale}/category/${slug}`,
         },
         twitter: {
             card: 'summary_large_image',

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -24,8 +24,20 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://ai-tool-navigator.vercel.app'),
   title: "AI Tool Navigator | Best AI Tools Comparison",
   description: "Compare the best AI tools for writing, coding, image generation, and more. Find the perfect AI solution for your workflow.",
+  openGraph: {
+    type: 'website',
+    siteName: 'AI Tool Navigator',
+    title: "AI Tool Navigator | Best AI Tools Comparison",
+    description: "Compare the best AI tools for writing, coding, image generation, and more. Find the perfect AI solution for your workflow.",
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: "AI Tool Navigator | Best AI Tools Comparison",
+    description: "Compare the best AI tools for writing, coding, image generation, and more. Find the perfect AI solution for your workflow.",
+  },
 };
 
 export default async function RootLayout({

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -1,0 +1,81 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+
+export const alt = 'AI Tool Navigator';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+
+  const title = 'AI Tool Navigator';
+  const description = locale === 'ja'
+    ? '最高のAIツールを発見・比較しましょう'
+    : 'Discover and compare the best AI tools for your workflow';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(to bottom right, #18181b, #09090b)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'sans-serif',
+          color: 'white',
+          padding: '40px',
+          textAlign: 'center',
+        }}
+      >
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginBottom: '20px',
+            }}
+        >
+             {/* Logo or Icon could go here */}
+            <div
+                style={{
+                    fontSize: 60,
+                    fontWeight: 'bold',
+                    background: 'linear-gradient(to right, #3b82f6, #a855f7)',
+                    backgroundClip: 'text',
+                    color: 'transparent',
+                }}
+            >
+            {title}
+            </div>
+        </div>
+
+        <div style={{ fontSize: 30, color: '#e4e4e7', maxWidth: '80%', lineHeight: 1.5 }}>
+          {description}
+        </div>
+
+        <div style={{
+            marginTop: '40px',
+            display: 'flex',
+            alignItems: 'center',
+            background: 'rgba(255, 255, 255, 0.1)',
+            padding: '10px 20px',
+            borderRadius: '20px',
+            border: '1px solid rgba(255, 255, 255, 0.2)',
+        }}>
+             <div style={{ fontSize: 20, color: '#a1a1aa' }}>ai-tool-navigator.vercel.app</div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/[locale]/tools/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/tools/[slug]/opengraph-image.tsx
@@ -1,0 +1,109 @@
+import { ImageResponse } from 'next/og';
+import { getToolBySlug } from '@/lib/tools';
+
+export const runtime = 'nodejs';
+
+export const alt = 'AI Tool Details';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+  const { slug, locale } = await params;
+  const tool = getToolBySlug(slug, locale);
+
+  if (!tool) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            fontSize: 48,
+            background: 'white',
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          Tool not found
+        </div>
+      ),
+      { ...size }
+    );
+  }
+
+  const { metadata } = tool;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(to bottom right, #18181b, #09090b)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'sans-serif',
+          color: 'white',
+          padding: '40px',
+          textAlign: 'center',
+          position: 'relative',
+        }}
+      >
+        <div
+            style={{
+                position: 'absolute',
+                top: 40,
+                left: 40,
+                fontSize: 24,
+                color: '#a1a1aa',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+            }}
+        >
+            <span style={{ color: '#3b82f6' }}>AI Tool Navigator</span>
+             <span>/</span>
+            <span>{metadata.category}</span>
+        </div>
+
+        <div
+          style={{
+            fontSize: 80,
+            fontWeight: 'bold',
+            marginBottom: 20,
+            background: 'linear-gradient(to right, #fff, #a1a1aa)',
+            backgroundClip: 'text',
+            color: 'transparent',
+            lineHeight: 1.1,
+          }}
+        >
+          {metadata.title}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginTop: 20 }}>
+            {/* Simple star representation since we can't easily loop in JSX inside ImageResponse without creating an array */}
+             <div style={{ display: 'flex' }}>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} style={{ fontSize: 40, color: i < Math.round(metadata.rating) ? '#facc15' : '#52525b' }}>★</div>
+              ))}
+            </div>
+            <div style={{ fontSize: 30, color: '#e4e4e7', marginLeft: 10 }}>{metadata.rating}/5</div>
+        </div>
+
+         <div style={{ fontSize: 30, color: '#d4d4d8', maxWidth: '80%', marginTop: 30, lineHeight: 1.4, display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+          {metadata.description}
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -40,6 +40,7 @@ export async function generateMetadata(
       title,
       description,
       type: 'website',
+      url: `/${locale}/tools/${slug}`,
     },
     twitter: {
       card: 'summary_large_image',


### PR DESCRIPTION
Implemented OpenGraph (OG) Meta Tags and dynamic OG images using `next/og`. Added `opengraph-image.tsx` files for various routes and updated `generateMetadata` to include structured OG and Twitter card metadata. Set `metadataBase` in root layout for correct URL resolution.

---
*PR created automatically by Jules for task [2828340003247885414](https://jules.google.com/task/2828340003247885414) started by @yuga-hashimoto*