### PR TITLE
feat: Add Social Share Buttons

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -123,6 +123,14 @@
     "title": "AI Insights & Reviews",
     "description": "Deep dives into the latest AI tools, comparisons, and industry trends."
   },
+  "ShareButtons": {
+    "shareOnX": "Share on X",
+    "shareOnFacebook": "Share on Facebook",
+    "shareOnLinkedIn": "Share on LinkedIn",
+    "shareOnEmail": "Share via Email",
+    "shareThisPost": "Share this post",
+    "shareThisTool": "Share this tool"
+  },
   "Breadcrumbs": {
     "home": "Home",
     "blog": "Blog",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -123,6 +123,14 @@
     "title": "AIツール解説＆レビュー",
     "description": "最新のAIツール、比較、業界トレンドを深掘りします。"
   },
+  "ShareButtons": {
+    "shareOnX": "Xでシェア",
+    "shareOnFacebook": "Facebookでシェア",
+    "shareOnLinkedIn": "LinkedInでシェア",
+    "shareOnEmail": "メールでシェア",
+    "shareThisPost": "この記事をシェア",
+    "shareThisTool": "このツールをシェア"
+  },
   "Breadcrumbs": {
     "home": "ホーム",
     "blog": "ブログ",

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { getTranslations } from "next-intl/server";
 import { extractHeadings } from "@/lib/markdown";
 import { TableOfContents } from "@/components/TableOfContents";
+import { ShareButtons } from "@/components/ShareButtons";
 
 export async function generateStaticParams() {
   const params = [];
@@ -60,6 +61,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   const { slug, locale } = await params;
   const post = getPostBySlug(slug, locale);
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
+  const tShare = await getTranslations('ShareButtons');
 
   if (!post) {
     notFound();
@@ -67,6 +69,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
   const { metadata, content } = post;
   const headings = extractHeadings(content);
+  const url = `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}/blog/${slug}`;
 
   const breadcrumbItems: BreadcrumbItem[] = [
     { label: tBreadcrumbs('home'), href: '/' },
@@ -119,6 +122,9 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                                 ))}
                             </div>
                         )}
+                        <div className="flex justify-center mt-6">
+                            <ShareButtons url={url} title={metadata.title} />
+                        </div>
                     </header>
 
                     <div className="prose prose-lg prose-zinc dark:prose-invert">
@@ -133,8 +139,14 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                 </article>
             </main>
             <aside className="hidden lg:block lg:col-span-4">
-                 <div className="sticky top-24">
+                 <div className="sticky top-24 space-y-8">
                     <TableOfContents headings={headings} />
+                    <div>
+                        <h3 className="font-semibold text-zinc-900 dark:text-zinc-100 mb-4 uppercase tracking-wider text-xs">
+                            {tShare('shareThisPost')}
+                        </h3>
+                        <ShareButtons url={url} title={metadata.title} />
+                    </div>
                  </div>
             </aside>
         </div>

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { ProsConsSection } from "@/components/ProsConsSection";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { getCategorySlug } from "@/lib/breadcrumbs";
 import { CopyLinkButton } from "@/components/CopyLinkButton";
+import { ShareButtons } from "@/components/ShareButtons";
 
 export async function generateStaticParams() {
   const slugs = getToolSlugs();
@@ -55,6 +56,7 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
   const tool = getToolBySlug(slug, locale);
   const t = await getTranslations('ToolPage');
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
+  const tShare = await getTranslations('ShareButtons');
 
   if (!tool) {
     notFound();
@@ -65,6 +67,7 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
   const relatedTools = getRelatedTools(metadata, 3, locale);
   const relatedPosts = getRelatedPosts(metadata, 3, locale);
   const jsonLd = generateToolSchema(tool);
+  const url = `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}/tools/${slug}`;
 
   const categorySlug = getCategorySlug(metadata.category);
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -155,6 +158,13 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
 
                 <div className="mt-12 prose prose-zinc dark:prose-invert max-w-none">
                     <ReactMarkdown>{content}</ReactMarkdown>
+                </div>
+
+                <div className="mt-12 pt-8 border-t border-zinc-200 dark:border-zinc-800">
+                    <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+                        {tShare('shareThisTool')}
+                    </h3>
+                    <ShareButtons url={url} title={metadata.title} />
                 </div>
             </div>
         </div>

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Twitter, Facebook, Linkedin, Mail } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+interface ShareButtonsProps {
+  url: string;
+  title: string;
+}
+
+export function ShareButtons({ url, title }: ShareButtonsProps) {
+  const t = useTranslations("ShareButtons");
+
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+
+  const shareLinks = [
+    {
+      name: "X",
+      icon: Twitter,
+      href: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+      label: t("shareOnX"),
+      color: "hover:text-black dark:hover:text-white",
+    },
+    {
+      name: "Facebook",
+      icon: Facebook,
+      href: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+      label: t("shareOnFacebook"),
+      color: "hover:text-blue-600",
+    },
+    {
+      name: "LinkedIn",
+      icon: Linkedin,
+      href: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+      label: t("shareOnLinkedIn"),
+      color: "hover:text-blue-700",
+    },
+    {
+      name: "Email",
+      icon: Mail,
+      href: `mailto:?subject=${encodedTitle}&body=${encodedUrl}`,
+      label: t("shareOnEmail"),
+      color: "hover:text-gray-600 dark:hover:text-gray-300",
+    },
+  ];
+
+  return (
+    <div className="flex gap-4">
+      {shareLinks.map((link) => (
+        <a
+          key={link.name}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={link.label}
+          className={`text-zinc-400 transition-colors duration-200 ${link.color}`}
+        >
+          <link.icon className="h-5 w-5" />
+        </a>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Added social share buttons to blog post and tool detail pages. The buttons allow users to share the current page on X (Twitter), Facebook, LinkedIn, and via Email. The implementation uses a reusable `ShareButtons` component and supports internationalization. The buttons are placed prominently in the blog post header and sidebar, and at the bottom of the tool detail content.

---
*PR created automatically by Jules for task [15324621114469849973](https://jules.google.com/task/15324621114469849973) started by @yuga-hashimoto*