### PR TITLE
fix: Resolve merge conflicts in Copy Link Button PR

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,22 @@
+
+> ai-tool-navigator@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 2.3s
+○ Compiling /[locale] ...
+ GET /en 200 in 8.5s (compile: 7.3s, proxy.ts: 8ms, render: 1204ms)
+ GET /en 200 in 182ms (compile: 88ms, proxy.ts: 36ms, render: 58ms)
+ GET /en 200 in 1442ms (compile: 715ms, proxy.ts: 21ms, render: 706ms)
+ GET /en 200 in 147ms (compile: 54ms, proxy.ts: 9ms, render: 84ms)
+ GET /en 200 in 290ms (compile: 38ms, proxy.ts: 5ms, render: 247ms)


### PR DESCRIPTION
Resolved merge conflicts by merging `origin/main` into the PR branch `feat-copy-link-button-14172010260637052320`. The `CopyLinkButton` feature was verified to be present and functional in `main`. The merge ensures the branch is up to date and consistent with `main` while preserving the feature and resolving unrelated history issues. Verified with Playwright script.

---
*PR created automatically by Jules for task [2757262031594757703](https://jules.google.com/task/2757262031594757703) started by @yuga-hashimoto*