### PR TITLE
Add BlogPosting schema to blog articles

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { extractHeadings } from "@/lib/markdown";
 import { TableOfContents } from "@/components/TableOfContents";
 import { ShareButtons } from "@/components/ShareButtons";
 import { ReadingProgressBar } from "@/components/ReadingProgressBar";
+import { generateBlogPostSchema } from "@/lib/schema";
 
 export async function generateStaticParams() {
   const params = [];
@@ -73,6 +74,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   const { metadata, content } = post;
   const headings = extractHeadings(content);
   const url = `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}/blog/${slug}`;
+  const schema = generateBlogPostSchema(post, url);
 
   const breadcrumbItems: BreadcrumbItem[] = [
     { label: tBreadcrumbs('home'), href: '/' },
@@ -101,6 +103,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
   return (
     <div className="bg-white dark:bg-black min-h-screen py-12 transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
       <ReadingProgressBar />
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <Breadcrumbs items={breadcrumbItems} />

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,4 +1,5 @@
 import { Tool } from "@/lib/tools";
+import { Post } from "@/lib/posts";
 
 const APPLICATION_CATEGORY_MAP: Record<string, string> = {
   "Video Generation": "MultimediaApplication",
@@ -84,6 +85,39 @@ export function generateToolSchema(tool: Tool) {
       },
       reviewBody: metadata.description,
     };
+  }
+
+  return schema;
+}
+
+export function generateBlogPostSchema(post: Post, url: string) {
+  const { metadata } = post;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const schema: any = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: metadata.title,
+    description: metadata.excerpt,
+    datePublished: metadata.date,
+    dateModified: metadata.date,
+    author: {
+      "@type": "Person",
+      name: metadata.author,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "AI Tool Navigator",
+    },
+    url: url,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+  };
+
+  if (metadata.image) {
+    schema.image = metadata.image;
   }
 
   return schema;


### PR DESCRIPTION
This PR adds Schema.org `BlogPosting` structured data to all blog article pages. This enhancement improves SEO by helping search engines better understand and index the blog content.

Key changes:
- Added `generateBlogPostSchema` function to `src/lib/schema.ts`.
- Updated `src/app/[locale]/blog/[slug]/page.tsx` to generate and inject the JSON-LD script using `dangerouslySetInnerHTML`.
- The schema includes `headline`, `description`, `datePublished`, `author`, `publisher` (as "AI Tool Navigator"), and `image` (if available).

---
*PR created automatically by Jules for task [8971687835572350136](https://jules.google.com/task/8971687835572350136) started by @yuga-hashimoto*