### PR TITLE
feat: Implement GA4 Event Tracking for Affiliate Clicks

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -13,8 +13,6 @@ You can learn more, including how to opt-out if you'd not like to participate in
 https://nextjs.org/telemetry
 
 ⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
-✓ Ready in 2.2s
-○ Compiling /[locale] ...
- GET /en 200 in 10.4s (compile: 8.8s, proxy.ts: 19ms, render: 1606ms)
- GET /en/tools/kling-ai 200 in 3.1s (compile: 2.6s, proxy.ts: 5ms, generate-params: 1068ms, render: 507ms)
- GET /en/tools/sora-2 200 in 733ms (compile: 154ms, proxy.ts: 25ms, generate-params: 37ms, render: 554ms)
+✓ Ready in 2.1s
+○ Compiling /[locale]/tools/[slug] ...
+ GET /en/tools/chatgpt 200 in 9.3s (compile: 7.5s, proxy.ts: 187ms, generate-params: 1163ms, render: 1622ms)

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { getCategorySlug } from "@/lib/breadcrumbs";
 import { CopyLinkButton } from "@/components/CopyLinkButton";
 import { ShareButtons } from "@/components/ShareButtons";
+import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
 
 export async function generateStaticParams() {
   const slugs = getToolSlugs();
@@ -120,14 +121,15 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                     </div>
                     <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
                         <CopyLinkButton className="w-full sm:w-auto" />
-                        <a
+                        <AffiliateLinkButton
                             href={metadata.affiliate_link}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                            toolSlug={metadata.slug}
+                            toolName={metadata.title}
+                            position="hero_section"
                             className="inline-flex w-full sm:w-auto items-center justify-center rounded-full bg-green-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-green-500 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 transition-all transform hover:scale-105"
                         >
                             {t('tryThisTool')} <ExternalLink className="ml-2 h-4 w-4" />
-                        </a>
+                        </AffiliateLinkButton>
                     </div>
                 </div>
 

--- a/src/components/AffiliateLinkButton.tsx
+++ b/src/components/AffiliateLinkButton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { sendGAEvent } from "@/lib/analytics";
+import { ReactNode } from "react";
+
+interface AffiliateLinkButtonProps {
+  href: string;
+  toolSlug: string;
+  toolName: string;
+  className?: string;
+  children: ReactNode;
+  position?: string;
+}
+
+export function AffiliateLinkButton({
+  href,
+  toolSlug,
+  toolName,
+  className,
+  children,
+  position = "tool_page",
+}: AffiliateLinkButtonProps) {
+  const handleClick = () => {
+    sendGAEvent("affiliate_click", {
+      tool_slug: toolSlug,
+      tool_name: toolName,
+      location: window.location.pathname,
+      position,
+    });
+  };
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      onClick={handleClick}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/CompareView.tsx
+++ b/src/components/CompareView.tsx
@@ -5,6 +5,7 @@ import { useCompare } from "@/context/CompareContext";
 import Link from "next/link";
 import { Check, X } from "lucide-react";
 import { Rating } from "@/components/Rating";
+import { sendGAEvent } from "@/lib/analytics";
 
 interface CompareViewProps {
   tools: ToolMetadata[];
@@ -132,6 +133,11 @@ export function CompareView({ tools }: CompareViewProps) {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="inline-flex items-center justify-center rounded-md bg-green-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+                            onClick={() => sendGAEvent("affiliate_click", {
+                              tool_slug: tool.slug,
+                              tool_name: tool.title,
+                              position: "compare_table"
+                            })}
                         >
                             Visit Site
                         </a>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type GTag = (...args: any[]) => void;
+
+declare global {
+  interface Window {
+    gtag?: GTag;
+  }
+}
+
+export const sendGAEvent = (eventName: string, params?: Record<string, string | number | boolean | null | undefined>) => {
+  if (typeof window !== "undefined" && window.gtag) {
+    window.gtag("event", eventName, params);
+  }
+};


### PR DESCRIPTION
Implemented Google Analytics 4 (GA4) event tracking for affiliate link clicks on the Tool Detail page and the Comparison View. This allows tracking of outbound clicks to affiliate partners with detailed parameters including tool slug, tool name, location, and position (e.g., 'hero_section', 'compare_table').

Changes:
- **New Utility:** `src/lib/analytics.ts` exports `sendGAEvent` to safely interact with `window.gtag`.
- **New Component:** `src/components/AffiliateLinkButton.tsx` wraps the affiliate link and handles the click event.
- **Tool Page Update:** Replaced the static `<a>` tag in `src/app/[locale]/tools/[slug]/page.tsx` with `AffiliateLinkButton`.
- **Compare View Update:** Added `onClick` handler to the "Visit Site" button in `src/components/CompareView.tsx` to trigger the `affiliate_click` event.


---
*PR created automatically by Jules for task [14706047500127613271](https://jules.google.com/task/14706047500127613271) started by @yuga-hashimoto*