### PR TITLE
perf: Optimize Image Loading with Priority

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -174,7 +174,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                             {tBlog('recentPosts')}
                          </h3>
                          <ul className="space-y-6">
-                            {recentPosts.map((post) => (
+                            {recentPosts.map((post, index) => (
                                 <li key={post.slug} className="group">
                                     <Link href={`/blog/${post.slug}`} className="flex gap-4">
                                          {post.image && (
@@ -183,6 +183,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                                                     src={post.image}
                                                     alt={post.title}
                                                     fill
+                                                    priority={index < 2}
                                                     className="object-cover group-hover:scale-105 transition-transform duration-300"
                                                 />
                                              </div>

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -37,8 +37,8 @@ export default async function BlogPage({
           </p>
         </div>
         <div className="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-          {posts.map((post) => (
-            <ArticleCard key={post.slug} post={post} locale={locale} />
+          {posts.map((post, index) => (
+            <ArticleCard key={post.slug} post={post} locale={locale} priority={index < 3} />
           ))}
         </div>
       </div>

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -5,9 +5,10 @@ import Image from "next/image";
 interface ArticleCardProps {
   post: PostMetadata;
   locale: string;
+  priority?: boolean;
 }
 
-export function ArticleCard({ post, locale }: ArticleCardProps) {
+export function ArticleCard({ post, locale, priority = false }: ArticleCardProps) {
   const dateOptions: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
@@ -23,6 +24,7 @@ export function ArticleCard({ post, locale }: ArticleCardProps) {
             src={post.image}
             alt={post.title}
             fill
+            priority={priority}
             className="object-cover transition-transform duration-300 hover:scale-105"
           />
         </div>

--- a/src/components/SponsoredTools.tsx
+++ b/src/components/SponsoredTools.tsx
@@ -27,9 +27,9 @@ export function SponsoredTools({ tools }: SponsoredToolsProps) {
       </div>
 
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {sponsoredTools.map((tool) => (
+        {sponsoredTools.map((tool, index) => (
           <div key={tool.slug} className="flex flex-col h-full">
-            <ToolCard tool={tool} />
+            <ToolCard tool={tool} priority={index < 3} />
           </div>
         ))}
       </div>

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -9,7 +9,12 @@ import { MouseEvent } from 'react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
-export function ToolCard({ tool }: { tool: ToolMetadata }) {
+interface ToolCardProps {
+  tool: ToolMetadata;
+  priority?: boolean;
+}
+
+export function ToolCard({ tool, priority = false }: ToolCardProps) {
   const { selectedSlugs, toggleTool } = useCompare();
   const isSelected = selectedSlugs.includes(tool.slug);
   const t = useTranslations('ToolCard');
@@ -35,6 +40,7 @@ export function ToolCard({ tool }: { tool: ToolMetadata }) {
             src={tool.image}
             alt={tool.title}
             fill
+            priority={priority}
             className="object-cover transition-transform duration-300 group-hover:scale-105"
           />
         </div>

--- a/src/components/ToolOfTheWeek.tsx
+++ b/src/components/ToolOfTheWeek.tsx
@@ -80,6 +80,7 @@ export function ToolOfTheWeek({ tool }: ToolOfTheWeekProps) {
                         src={tool.image}
                         alt={tool.title}
                         fill
+                        priority={true}
                         className="object-cover"
                     />
                  ) : (


### PR DESCRIPTION
This PR optimizes image loading performance by adding a `priority` prop to `ToolCard` and `ArticleCard` components. This prop is then utilized in key above-the-fold sections such as `SponsoredTools`, `ToolOfTheWeek`, and the top posts in the Blog listing and sidebar, ensuring critical images load faster and improving Core Web Vitals (LCP).

---
*PR created automatically by Jules for task [10173963778976158477](https://jules.google.com/task/10173963778976158477) started by @yuga-hashimoto*