### PR TITLE
feat: Implement detailed Rating System for AI Tools

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -81,6 +81,7 @@
     "pros": "Pros",
     "cons": "Cons",
     "prosConsTitle": "Pros & Cons",
+    "ratingBreakdown": "Rating Breakdown",
     "relatedTools": "Related Tools",
     "relatedArticles": "Related Articles",
     "toolNotFound": "Tool Not Found",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -81,6 +81,7 @@
     "pros": "長所",
     "cons": "短所",
     "prosConsTitle": "長所と短所",
+    "ratingBreakdown": "評価の内訳",
     "relatedTools": "関連ツール",
     "relatedArticles": "関連記事",
     "toolNotFound": "ツールが見つかりません",

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { ArticleCard } from "@/components/ArticleCard";
 import { getTranslations } from "next-intl/server";
 import { generateToolSchema } from "@/lib/schema";
 import { ProsConsSection } from "@/components/ProsConsSection";
+import { RatingBreakdown } from "@/components/RatingBreakdown";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { getCategorySlug } from "@/lib/breadcrumbs";
 import { CopyLinkButton } from "@/components/CopyLinkButton";
@@ -142,6 +143,13 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                         cons: t('cons'),
                     }}
                 />
+
+                {metadata.rating_breakdown && (
+                    <RatingBreakdown
+                        breakdown={metadata.rating_breakdown}
+                        title={t('ratingBreakdown')}
+                    />
+                )}
 
                 <div className="mt-12 prose prose-zinc dark:prose-invert max-w-none">
                     <ReactMarkdown>{content}</ReactMarkdown>

--- a/src/components/RatingBreakdown.tsx
+++ b/src/components/RatingBreakdown.tsx
@@ -1,0 +1,44 @@
+import { Rating } from "@/components/Rating";
+
+interface RatingBreakdownProps {
+  breakdown: Record<string, number>;
+  title: string;
+}
+
+export function RatingBreakdown({ breakdown, title }: RatingBreakdownProps) {
+  if (!breakdown || Object.keys(breakdown).length === 0) {
+    return null;
+  }
+
+  const formatKey = (key: string) => {
+    return key
+      .split(/[-_]/)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
+  return (
+    <div className="mt-12">
+      <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-white mb-6">
+        {title}
+      </h2>
+      <div className="rounded-2xl bg-zinc-50 p-6 ring-1 ring-zinc-900/5 dark:bg-white/5 dark:ring-white/10">
+        <div className="grid grid-cols-1 gap-y-4 gap-x-12 sm:grid-cols-2">
+          {Object.entries(breakdown).map(([key, rating]) => (
+            <div key={key} className="flex items-center justify-between">
+              <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                {formatKey(key)}
+              </span>
+              <Rating
+                rating={rating}
+                size="h-4 w-4"
+                showText={true}
+                compact={false}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -10,6 +10,7 @@ export interface ToolMetadata {
   category: string;
   description: string;
   rating: number;
+  rating_breakdown?: Record<string, number>;
   image?: string;
   pros?: string[];
   cons?: string[];


### PR DESCRIPTION
This PR implements a detailed rating system for AI tools. It allows tool metadata to include a `rating_breakdown` object (e.g., Ease of Use, Features, Value, Support). A new `RatingBreakdown` component visualizes this breakdown on the tool detail page. Localization is supported for the section title. Existing functionality for overall rating is preserved.

---
*PR created automatically by Jules for task [9501490930720329404](https://jules.google.com/task/9501490930720329404) started by @yuga-hashimoto*