### PR TITLE
feat(seo): Implement Canonical Tags for all pages

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -10,6 +10,9 @@ export async function generateMetadata({
   return {
     title: t('title'),
     description: t('description'),
+    alternates: {
+      canonical: `/${locale}/about`,
+    }
   };
 }
 

--- a/src/app/[locale]/advertise/page.tsx
+++ b/src/app/[locale]/advertise/page.tsx
@@ -1,4 +1,20 @@
 import React from 'react';
+import { Metadata } from 'next';
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Advertise - AI Tool Navigator",
+    description: "Sponsor AI Tools Navigator and reach thousands of developers.",
+    alternates: {
+      canonical: `/${locale}/advertise`,
+    }
+  };
+}
 
 export default function AdvertisePage() {
   return (

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -44,6 +44,9 @@ export async function generateMetadata(
   return {
     title,
     description,
+    alternates: {
+      canonical: `/${locale}/blog/${slug}`,
+    },
     openGraph: {
       title,
       description,

--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -36,6 +36,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     return {
         title: fullTitle,
         description: description,
+        alternates: {
+            canonical: `/${locale}/category/${slug}`,
+        },
         openGraph: {
             title: fullTitle,
             description: description,

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -5,13 +5,28 @@ import Link from 'next/link';
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { getTranslations } from "next-intl/server";
 
-export const metadata: Metadata = {
-  title: "Compare AI Tools | AI Tool Navigator",
-  description: "Compare features, pricing, pros, and cons of top AI tools side-by-side.",
-};
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Compare AI Tools | AI Tool Navigator",
+    description: "Compare features, pricing, pros, and cons of top AI tools side-by-side.",
+    alternates: {
+      canonical: `/${locale}/compare`,
+    }
+  };
+}
 
-export default async function ComparePage() {
-  const tools = getAllTools();
+export default async function ComparePage({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params;
+  const tools = getAllTools(locale);
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
 
   const breadcrumbItems: BreadcrumbItem[] = [

--- a/src/app/[locale]/deals/page.tsx
+++ b/src/app/[locale]/deals/page.tsx
@@ -13,6 +13,9 @@ export async function generateMetadata({
   return {
     title: t('title'),
     description: t('description'),
+    alternates: {
+      canonical: `/${locale}/deals`,
+    }
   };
 }
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -9,11 +9,22 @@ import { Link } from "@/i18n/routing";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from 'next-intl/server';
 import { Suspense } from 'react';
+import { Metadata } from 'next';
 
-export const metadata = {
-  title: "AI Tool Navigator",
-  description: "Discover and compare the best AI tools for your workflow.",
-};
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "AI Tool Navigator",
+    description: "Discover and compare the best AI tools for your workflow.",
+    alternates: {
+      canonical: `/${locale}`,
+    }
+  };
+}
 
 export default async function Home({
   params

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: "Privacy Policy - AI Tool Navigator",
-  description: "Privacy Policy for AI Tool Navigator",
-};
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Privacy Policy - AI Tool Navigator",
+    description: "Privacy Policy for AI Tool Navigator",
+    alternates: {
+      canonical: `/${locale}/privacy`,
+    }
+  };
+}
 
 export default function PrivacyPage() {
   return (

--- a/src/app/[locale]/sponsor/page.tsx
+++ b/src/app/[locale]/sponsor/page.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
+import { Metadata } from 'next';
 
-export const metadata = {
-  title: "Sponsorship - AI Tool Navigator",
-  description: "Promote your AI tool to our audience of developers and enthusiasts.",
-};
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Sponsorship - AI Tool Navigator",
+    description: "Promote your AI tool to our audience of developers and enthusiasts.",
+    alternates: {
+      canonical: `/${locale}/sponsor`,
+    }
+  };
+}
 
 export default function SponsorshipPage() {
   return (

--- a/src/app/[locale]/submit/page.tsx
+++ b/src/app/[locale]/submit/page.tsx
@@ -1,198 +1,22 @@
-'use client';
+import { SubmitToolForm } from '@/components/SubmitToolForm';
+import { getTranslations } from 'next-intl/server';
 
-import { useTranslations } from 'next-intl';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { useState } from 'react';
-import { Loader2 } from 'lucide-react';
-
-const submissionSchema = z.object({
-  name: z.string().min(1, 'Tool name is required'),
-  url: z.string().url('Please enter a valid URL'),
-  description: z.string().min(10, 'Description must be at least 10 characters'),
-  category: z.string().min(1, 'Category is required'),
-});
-
-type SubmissionFormData = z.infer<typeof submissionSchema>;
-
-export default function SubmitPage() {
-  const t = useTranslations('SubmitPage');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
-
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm<SubmissionFormData>({
-    resolver: zodResolver(submissionSchema),
-  });
-
-  const onSubmit = async (data: SubmissionFormData) => {
-    setIsSubmitting(true);
-    setSubmitStatus('idle');
-
-    try {
-      const response = await fetch('/api/submit', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      });
-
-      if (!response.ok) {
-        throw new Error('Submission failed');
-      }
-
-      setSubmitStatus('success');
-      reset();
-    } catch (error) {
-      console.error('Submission error:', error);
-      setSubmitStatus('error');
-    } finally {
-      setIsSubmitting(false);
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({locale, namespace: 'SubmitPage'});
+  return {
+    title: t('title'),
+    description: t('description'),
+    alternates: {
+        canonical: `/${locale}/submit`,
     }
   };
+}
 
-  return (
-    <div className="bg-white dark:bg-black min-h-screen py-16 sm:py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
-            {t('title')}
-          </h2>
-          <p className="mt-2 text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            {t('description')}
-          </p>
-        </div>
-
-        <div className="mx-auto max-w-xl mt-10">
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-            <div>
-              <label htmlFor="name" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
-                {t('form.name')}
-              </label>
-              <div className="mt-2">
-                <input
-                  id="name"
-                  type="text"
-                  {...register('name')}
-                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
-                />
-                {errors.name && (
-                  <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>
-                )}
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="url" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
-                {t('form.url')}
-              </label>
-              <div className="mt-2">
-                <input
-                  id="url"
-                  type="url"
-                  {...register('url')}
-                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
-                  placeholder="https://example.com"
-                />
-                {errors.url && (
-                  <p className="mt-1 text-sm text-red-600">{errors.url.message}</p>
-                )}
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="category" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
-                {t('form.category')}
-              </label>
-              <div className="mt-2">
-                <input
-                  id="category"
-                  type="text"
-                  {...register('category')}
-                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
-                />
-                {errors.category && (
-                  <p className="mt-1 text-sm text-red-600">{errors.category.message}</p>
-                )}
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="description" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
-                {t('form.description')}
-              </label>
-              <div className="mt-2">
-                <textarea
-                  id="description"
-                  rows={4}
-                  {...register('description')}
-                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
-                />
-                {errors.description && (
-                  <p className="mt-1 text-sm text-red-600">{errors.description.message}</p>
-                )}
-              </div>
-            </div>
-
-            <div>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="flex w-full justify-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    {t('form.submitting')}
-                  </>
-                ) : (
-                  t('form.submit')
-                )}
-              </button>
-            </div>
-            
-            {submitStatus === 'success' && (
-              <div className="rounded-md bg-green-50 p-4 dark:bg-green-900/30">
-                <div className="flex">
-                  <div className="flex-shrink-0">
-                    <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
-                    </svg>
-                  </div>
-                  <div className="ml-3">
-                    <p className="text-sm font-medium text-green-800 dark:text-green-200">
-                      {t('form.success')}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {submitStatus === 'error' && (
-              <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/30">
-                <div className="flex">
-                  <div className="flex-shrink-0">
-                     <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clipRule="evenodd" />
-                    </svg>
-                  </div>
-                  <div className="ml-3">
-                    <p className="text-sm font-medium text-red-800 dark:text-red-200">
-                      {t('form.error')}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-          </form>
-        </div>
-      </div>
-    </div>
-  );
+export default function SubmitPage() {
+  return <SubmitToolForm />;
 }

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: "Terms of Service - AI Tool Navigator",
-  description: "Terms of Service for AI Tool Navigator",
-};
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Terms of Service - AI Tool Navigator",
+    description: "Terms of Service for AI Tool Navigator",
+    alternates: {
+      canonical: `/${locale}/terms`,
+    }
+  };
+}
 
 export default function TermsPage() {
   return (

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -39,6 +39,9 @@ export async function generateMetadata(
   return {
     title,
     description,
+    alternates: {
+        canonical: `/${locale}/tools/${slug}`,
+    },
     openGraph: {
       title,
       description,

--- a/src/components/SubmitToolForm.tsx
+++ b/src/components/SubmitToolForm.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+
+const submissionSchema = z.object({
+  name: z.string().min(1, 'Tool name is required'),
+  url: z.string().url('Please enter a valid URL'),
+  description: z.string().min(10, 'Description must be at least 10 characters'),
+  category: z.string().min(1, 'Category is required'),
+});
+
+type SubmissionFormData = z.infer<typeof submissionSchema>;
+
+export function SubmitToolForm() {
+  const t = useTranslations('SubmitPage');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<SubmissionFormData>({
+    resolver: zodResolver(submissionSchema),
+  });
+
+  const onSubmit = async (data: SubmissionFormData) => {
+    setIsSubmitting(true);
+    setSubmitStatus('idle');
+
+    try {
+      const response = await fetch('/api/submit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        throw new Error('Submission failed');
+      }
+
+      setSubmitStatus('success');
+      reset();
+    } catch (error) {
+      console.error('Submission error:', error);
+      setSubmitStatus('error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-black min-h-screen py-16 sm:py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
+            {t('title')}
+          </h2>
+          <p className="mt-2 text-lg leading-8 text-zinc-600 dark:text-zinc-400">
+            {t('description')}
+          </p>
+        </div>
+
+        <div className="mx-auto max-w-xl mt-10">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
+                {t('form.name')}
+              </label>
+              <div className="mt-2">
+                <input
+                  id="name"
+                  type="text"
+                  {...register('name')}
+                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
+                />
+                {errors.name && (
+                  <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="url" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
+                {t('form.url')}
+              </label>
+              <div className="mt-2">
+                <input
+                  id="url"
+                  type="url"
+                  {...register('url')}
+                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
+                  placeholder="https://example.com"
+                />
+                {errors.url && (
+                  <p className="mt-1 text-sm text-red-600">{errors.url.message}</p>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="category" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
+                {t('form.category')}
+              </label>
+              <div className="mt-2">
+                <input
+                  id="category"
+                  type="text"
+                  {...register('category')}
+                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
+                />
+                {errors.category && (
+                  <p className="mt-1 text-sm text-red-600">{errors.category.message}</p>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="description" className="block text-sm font-medium leading-6 text-zinc-900 dark:text-white">
+                {t('form.description')}
+              </label>
+              <div className="mt-2">
+                <textarea
+                  id="description"
+                  rows={4}
+                  {...register('description')}
+                  className="block w-full rounded-md border-0 py-1.5 text-zinc-900 shadow-sm ring-1 ring-inset ring-zinc-300 placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 dark:bg-zinc-800 dark:text-white dark:ring-zinc-700"
+                />
+                {errors.description && (
+                  <p className="mt-1 text-sm text-red-600">{errors.description.message}</p>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="flex w-full justify-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t('form.submitting')}
+                  </>
+                ) : (
+                  t('form.submit')
+                )}
+              </button>
+            </div>
+
+            {submitStatus === 'success' && (
+              <div className="rounded-md bg-green-50 p-4 dark:bg-green-900/30">
+                <div className="flex">
+                  <div className="flex-shrink-0">
+                    <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
+                    </svg>
+                  </div>
+                  <div className="ml-3">
+                    <p className="text-sm font-medium text-green-800 dark:text-green-200">
+                      {t('form.success')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {submitStatus === 'error' && (
+              <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/30">
+                <div className="flex">
+                  <div className="flex-shrink-0">
+                     <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clipRule="evenodd" />
+                    </svg>
+                  </div>
+                  <div className="ml-3">
+                    <p className="text-sm font-medium text-red-800 dark:text-red-200">
+                      {t('form.error')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implemented canonical tags for all pages to improve SEO.

Key changes:
- Refactored `SubmitPage` to be a Server Component to allow dynamic metadata generation.
- Added `alternates` with `canonical` URL to `generateMetadata` function in all pages:
  - Home
  - About
  - Advertise
  - Blog Post
  - Category
  - Compare
  - Deals
  - Privacy
  - Sponsor
  - Submit
  - Terms
  - Tool Detail
- Ensured localized canonical URLs (e.g., `/en/about`, `/ja/about`).
- Verified with `npm run build` and a custom verification script.
- Visually verified the `SubmitPage` refactor using Playwright.

---
*PR created automatically by Jules for task [6427907582576554435](https://jules.google.com/task/6427907582576554435) started by @yuga-hashimoto*