### PR TITLE
perf: Optimize Image Loading with Priority

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -7,12 +7,32 @@
 - Network:       http://192.168.0.2:3000
 
 ✓ Starting...
-Attention: Next.js now collects completely anonymous telemetry regarding usage.
-This information is used to shape Next.js' roadmap and prioritize features.
-You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
-https://nextjs.org/telemetry
-
 ⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
-✓ Ready in 2.1s
-○ Compiling /[locale]/tools/[slug] ...
- GET /en/tools/chatgpt 200 in 9.3s (compile: 7.5s, proxy.ts: 187ms, generate-params: 1163ms, render: 1622ms)
+✓ Ready in 1348ms
+ GET /en 200 in 2.6s (compile: 1759ms, proxy.ts: 8ms, render: 838ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 1331ms (compile: 910ms, generate-params: 725ms, render: 421ms)
+ GET /en 200 in 498ms (compile: 43ms, proxy.ts: 6ms, render: 449ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 389ms (compile: 25ms, generate-params: 21ms, render: 364ms)
+ GET /en 200 in 315ms (compile: 27ms, proxy.ts: 4ms, render: 284ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 482ms (compile: 24ms, generate-params: 21ms, render: 458ms)
+ GET /en 200 in 422ms (compile: 35ms, proxy.ts: 7ms, render: 379ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 275ms (compile: 25ms, generate-params: 21ms, render: 250ms)
+ GET /en 200 in 513ms (compile: 38ms, proxy.ts: 9ms, render: 466ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 440ms (compile: 27ms, generate-params: 21ms, render: 412ms)
+✓ Compiled in 75ms
+ GET /en 200 in 1156ms (compile: 107ms, proxy.ts: 14ms, render: 1036ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 937ms (compile: 270ms, generate-params: 22ms, render: 667ms)
+✓ Compiled in 67ms
+ GET /en 200 in 431ms (compile: 33ms, proxy.ts: 5ms, render: 393ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 1072ms (compile: 280ms, generate-params: 24ms, render: 791ms)
+✓ Compiled in 55ms
+ GET /en 200 in 378ms (compile: 32ms, proxy.ts: 6ms, render: 340ms)
+ GET /en/blog/llama-4.5-vs-gemini-3-pro 200 in 1016ms (compile: 259ms, generate-params: 21ms, render: 758ms)
+⚠ Found a change in next.config.ts. Restarting the server to apply the changes...
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 1263ms

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -174,7 +174,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                             {tBlog('recentPosts')}
                          </h3>
                          <ul className="space-y-6">
-                            {recentPosts.map((post) => (
+                            {recentPosts.map((post, index) => (
                                 <li key={post.slug} className="group">
                                     <Link href={`/blog/${post.slug}`} className="flex gap-4">
                                          {post.image && (
@@ -183,6 +183,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                                                     src={post.image}
                                                     alt={post.title}
                                                     fill
+                                                    priority={index < 2}
                                                     className="object-cover group-hover:scale-105 transition-transform duration-300"
                                                 />
                                              </div>

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -5,9 +5,10 @@ import Image from "next/image";
 interface ArticleCardProps {
   post: PostMetadata;
   locale: string;
+  priority?: boolean;
 }
 
-export function ArticleCard({ post, locale }: ArticleCardProps) {
+export function ArticleCard({ post, locale, priority }: ArticleCardProps) {
   const dateOptions: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
@@ -23,6 +24,7 @@ export function ArticleCard({ post, locale }: ArticleCardProps) {
             src={post.image}
             alt={post.title}
             fill
+            priority={priority}
             className="object-cover transition-transform duration-300 hover:scale-105"
           />
         </div>

--- a/src/components/SponsoredTools.tsx
+++ b/src/components/SponsoredTools.tsx
@@ -27,9 +27,9 @@ export function SponsoredTools({ tools }: SponsoredToolsProps) {
       </div>
 
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {sponsoredTools.map((tool) => (
+        {sponsoredTools.map((tool, index) => (
           <div key={tool.slug} className="flex flex-col h-full">
-            <ToolCard tool={tool} />
+            <ToolCard tool={tool} priority={index < 3} />
           </div>
         ))}
       </div>

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -9,7 +9,7 @@ import { MouseEvent } from 'react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
-export function ToolCard({ tool }: { tool: ToolMetadata }) {
+export function ToolCard({ tool, priority }: { tool: ToolMetadata; priority?: boolean }) {
   const { selectedSlugs, toggleTool } = useCompare();
   const isSelected = selectedSlugs.includes(tool.slug);
   const t = useTranslations('ToolCard');
@@ -35,6 +35,7 @@ export function ToolCard({ tool }: { tool: ToolMetadata }) {
             src={tool.image}
             alt={tool.title}
             fill
+            priority={priority}
             className="object-cover transition-transform duration-300 group-hover:scale-105"
           />
         </div>

--- a/src/components/ToolOfTheWeek.tsx
+++ b/src/components/ToolOfTheWeek.tsx
@@ -80,6 +80,7 @@ export function ToolOfTheWeek({ tool }: ToolOfTheWeekProps) {
                         src={tool.image}
                         alt={tool.title}
                         fill
+                        priority={true}
                         className="object-cover"
                     />
                  ) : (


### PR DESCRIPTION
This PR optimizes image loading performance by applying the `priority` property to key images that are likely to appear above the fold. 

Specifically:
- `ToolCard` and `ArticleCard` components were updated to accept a `priority` prop, which is passed down to the `next/image` component.
- In `SponsoredTools`, the first 3 tools (the first row on desktop) are now prioritized.
- In `ToolOfTheWeek`, the main tool image is prioritized.
- In the `BlogPostPage` sidebar, the first 2 recent post images are prioritized.

These changes ensure that critical visual elements load faster, improving the Largest Contentful Paint (LCP) metric and overall user experience. Verification was performed using a Playwright script to confirm that the `loading="lazy"` attribute is removed (indicating eager loading) for the targeted images.

---
*PR created automatically by Jules for task [4893846627550905157](https://jules.google.com/task/4893846627550905157) started by @yuga-hashimoto*