### PR TITLE
feat: Implement 'Share on X' with custom text

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,19 @@
+
+> ai-tool-navigator@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 1881ms
+○ Compiling /[locale]/tools/[slug] ...
+ GET /en/tools/kling-ai 200 in 8.1s (compile: 6.6s, proxy.ts: 175ms, generate-params: 1104ms, render: 1279ms)
+ GET /en/blog/best-ai-coding-tools-2026 200 in 2.5s (compile: 2.2s, proxy.ts: 18ms, generate-params: 785ms, render: 332ms)

--- a/messages/en.json
+++ b/messages/en.json
@@ -131,7 +131,9 @@
     "shareOnLinkedIn": "Share on LinkedIn",
     "shareOnEmail": "Share via Email",
     "shareThisPost": "Share this post",
-    "shareThisTool": "Share this tool"
+    "shareThisTool": "Share this tool",
+    "twitterShareTool": "Check out {toolName} on AI Tool Navigator!",
+    "twitterSharePost": "{postTitle} on AI Tool Navigator"
   },
   "Breadcrumbs": {
     "home": "Home",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -131,7 +131,9 @@
     "shareOnLinkedIn": "LinkedInでシェア",
     "shareOnEmail": "メールでシェア",
     "shareThisPost": "この記事をシェア",
-    "shareThisTool": "このツールをシェア"
+    "shareThisTool": "このツールをシェア",
+    "twitterShareTool": "AI Tool Navigatorで{toolName}をチェック！",
+    "twitterSharePost": "AI Tool Navigatorの記事: {postTitle}"
   },
   "Breadcrumbs": {
     "home": "ホーム",

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -154,7 +154,11 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                             </div>
                         )}
                         <div className="flex justify-center mt-6">
-                            <ShareButtons url={url} title={metadata.title} />
+                            <ShareButtons
+                                url={url}
+                                title={metadata.title}
+                                twitterText={tShare('twitterSharePost', { postTitle: metadata.title })}
+                            />
                         </div>
                     </header>
 
@@ -178,7 +182,11 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                             <h3 className="font-semibold text-zinc-900 dark:text-zinc-100 mb-4 uppercase tracking-wider text-xs">
                                 {tShare('shareThisPost')}
                             </h3>
-                            <ShareButtons url={url} title={metadata.title} />
+                            <ShareButtons
+                                url={url}
+                                title={metadata.title}
+                                twitterText={tShare('twitterSharePost', { postTitle: metadata.title })}
+                            />
                         </div>
                     </div>
 

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -162,7 +162,11 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                     <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
                         {tShare('shareThisTool')}
                     </h3>
-                    <ShareButtons url={url} title={metadata.title} />
+                    <ShareButtons
+                        url={url}
+                        title={metadata.title}
+                        twitterText={tShare('twitterShareTool', { toolName: metadata.title })}
+                    />
                 </div>
             </div>
         </div>

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -6,19 +6,23 @@ import { useTranslations } from "next-intl";
 interface ShareButtonsProps {
   url: string;
   title: string;
+  twitterText?: string;
 }
 
-export function ShareButtons({ url, title }: ShareButtonsProps) {
+export function ShareButtons({ url, title, twitterText }: ShareButtonsProps) {
   const t = useTranslations("ShareButtons");
 
   const encodedUrl = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);
+  const encodedTwitterText = twitterText
+    ? encodeURIComponent(twitterText)
+    : encodedTitle;
 
   const shareLinks = [
     {
       name: "X",
       icon: Twitter,
-      href: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+      href: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTwitterText}`,
       label: t("shareOnX"),
       color: "hover:text-black dark:hover:text-white",
     },


### PR DESCRIPTION
Implemented the 'Share on X (Twitter)' feature with custom text as requested.
Now, when sharing a tool or a blog post on X, the tweet body will be pre-filled with a custom message including the tool name or post title, localized for English and Japanese.

Changes:
- Modified `src/components/ShareButtons.tsx` to support `twitterText`.
- Added `twitterShareTool` and `twitterSharePost` translation keys.
- Updated `src/app/[locale]/tools/[slug]/page.tsx` and `src/app/[locale]/blog/[slug]/page.tsx` to use the new feature.

---
*PR created automatically by Jules for task [7727363737302553106](https://jules.google.com/task/7727363737302553106) started by @yuga-hashimoto*