### PR TITLE
Add Featured Tools section for monetization by renaming Promoted Tools

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,18 @@
+
+> ai-tool-navigator@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 2.1s
+○ Compiling /[locale] ...
+ GET /en 200 in 8.5s (compile: 6.9s, proxy.ts: 198ms, render: 1315ms)

--- a/messages/en.json
+++ b/messages/en.json
@@ -61,7 +61,7 @@
       "sponsored": "Sponsored"
   },
   "FeaturedCarousel": {
-      "title": "Featured Tools",
+      "title": "Trending Tools",
       "viewDeal": "View Deal",
       "learnMore": "Learn More"
   },
@@ -70,8 +70,8 @@
       "sponsored": "Sponsored"
   },
   "FeaturedTools": {
-      "title": "Promoted Tools",
-      "promoted": "Promoted",
+      "title": "Featured Tools",
+      "promoted": "Featured",
       "checkItOut": "Check it out"
   },
   "ToolPage": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -61,7 +61,7 @@
       "sponsored": "スポンサー"
   },
   "FeaturedCarousel": {
-      "title": "注目のツール",
+      "title": "話題のツール",
       "viewDeal": "詳細を見る",
       "learnMore": "もっと詳しく"
   },
@@ -70,8 +70,8 @@
       "sponsored": "スポンサー"
   },
   "FeaturedTools": {
-      "title": "プロモーションツール",
-      "promoted": "プロモーション",
+      "title": "注目のツール",
+      "promoted": "注目",
       "checkItOut": "チェックする"
   },
   "ToolPage": {

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -85,10 +85,10 @@ export default async function Home({
           </Link>
         </div>
 
-        {/* Featured Tools Carousel */}
+        {/* Trending Tools Carousel */}
         <FeaturedCarousel tools={tools} />
 
-        {/* Featured Tools Section (Promoted) */}
+        {/* Featured Tools Section */}
         <FeaturedTools tools={tools} />
 
         {/* Editor's Choice Section */}


### PR DESCRIPTION
This change renames the existing 'Promoted Tools' section to 'Featured Tools' to align with monetization goals, making paid placements appear as 'Featured'. To avoid confusion, the existing 'Featured Tools' carousel (which displays tools with `featured: true` flag) is renamed to 'Trending Tools'. This ensures a dedicated 'Featured Tools' section for monetization without duplicate section titles.

---
*PR created automatically by Jules for task [17186749091158030742](https://jules.google.com/task/17186749091158030742) started by @yuga-hashimoto*