### PR TITLE
feat: Add search bar to deals page

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -13,6 +13,12 @@ You can learn more, including how to opt-out if you'd not like to participate in
 https://nextjs.org/telemetry
 
 ⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
-✓ Ready in 2.1s
+✓ Ready in 2.8s
 ○ Compiling /[locale] ...
- GET /en 200 in 8.5s (compile: 6.9s, proxy.ts: 198ms, render: 1315ms)
+ GET /en 200 in 10.2s (compile: 8.6s, proxy.ts: 154ms, render: 1414ms)
+ GET /en 200 in 421ms (compile: 45ms, proxy.ts: 12ms, render: 364ms)
+ GET /en/deals 200 in 2.3s (compile: 2.0s, proxy.ts: 11ms, render: 230ms)
+✓ Compiled in 1043ms
+ GET /en/deals 200 in 1799ms (compile: 805ms, proxy.ts: 32ms, render: 962ms)
+ GET /en 200 in 465ms (compile: 52ms, proxy.ts: 13ms, render: 400ms)
+ GET /en/category/video 200 in 3.9s (compile: 3.6s, proxy.ts: 10ms, render: 371ms)

--- a/src/app/[locale]/deals/page.tsx
+++ b/src/app/[locale]/deals/page.tsx
@@ -1,7 +1,8 @@
 import { getAllTools } from "@/lib/tools";
-import { ToolCard } from "@/components/ToolCard";
+import { ToolGrid } from "@/components/ToolGrid";
 import { getTranslations } from 'next-intl/server';
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { Suspense } from 'react';
 
 export async function generateMetadata({
   params
@@ -49,11 +50,9 @@ export default async function DealsPage({
         </div>
 
         {deals.length > 0 ? (
-          <div className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:gap-x-8">
-            {deals.map((tool) => (
-              <ToolCard key={tool.slug} tool={tool} />
-            ))}
-          </div>
+          <Suspense fallback={<div className="py-12 text-center">Loading deals...</div>}>
+            <ToolGrid tools={deals} />
+          </Suspense>
         ) : (
           <div className="text-center text-zinc-600 dark:text-zinc-400">
             No deals found at the moment.


### PR DESCRIPTION
Addressed the request to add a search bar to the tool listing page by updating the Deals page (`src/app/[locale]/deals/page.tsx`).

Key changes:
- Replaced the manual `ToolCard` grid rendering with the `ToolGrid` component.
- `ToolGrid` provides built-in search and category filtering capabilities.
- Wrapped `ToolGrid` in a `Suspense` boundary for consistent loading behavior.
- Removed unused `ToolCard` import.

This ensures a consistent user experience across all tool listing pages (Home, Category, and now Deals).

---
*PR created automatically by Jules for task [18409027876368190688](https://jules.google.com/task/18409027876368190688) started by @yuga-hashimoto*