### PR TITLE
perf: Reduce unused CSS in Tailwind build by restricting source scanning

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../**";
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
Updated `src/app/globals.css` to include the `@source "../**";` directive.
This change ensures that Tailwind CSS v4's automatic content detection is scoped strictly to the `src` directory (relative to `src/app/globals.css`), preventing it from scanning extraneous files like `README.md`, config files, or `content/` directory files which might contain strings resembling Tailwind utility classes but are not intended to generate styles.
Verified that the build succeeds and CSS generation remains consistent for the current codebase.

---
*PR created automatically by Jules for task [17534616680479396049](https://jules.google.com/task/17534616680479396049) started by @yuga-hashimoto*