### PR TITLE
feat: Implement 'Tool of the Week' sidebar widget

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -17,6 +17,8 @@ import { ShareButtons } from "@/components/ShareButtons";
 import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { RelatedPost } from "@/components/RelatedPost";
 import { generateBlogPostSchema } from "@/lib/schema";
+import { getToolOfTheWeek } from "@/lib/tools";
+import { ToolOfTheWeekSidebar } from "@/components/ToolOfTheWeekSidebar";
 
 export async function generateStaticParams() {
   const params = [];
@@ -93,6 +95,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   const recentPosts = allPosts
     .filter((p) => p.slug !== slug)
     .slice(0, 5);
+
+  const toolOfTheWeek = getToolOfTheWeek(locale);
 
   const dateLocale = locale === 'ja' ? 'ja-JP' : 'en-US';
 
@@ -198,6 +202,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                             />
                         </div>
                     </div>
+
+                    <ToolOfTheWeekSidebar tool={toolOfTheWeek} />
 
                     <div>
                          <h3 className="text-xl font-semibold mb-6 text-zinc-900 dark:text-zinc-100">

--- a/src/components/ToolOfTheWeekSidebar.tsx
+++ b/src/components/ToolOfTheWeekSidebar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ToolMetadata } from '@/lib/tools';
+import { Link } from '@/i18n/routing';
+import { Zap, ArrowRight } from 'lucide-react';
+import { Rating } from '@/components/Rating';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+
+interface ToolOfTheWeekSidebarProps {
+  tool: ToolMetadata | null;
+}
+
+export function ToolOfTheWeekSidebar({ tool }: ToolOfTheWeekSidebarProps) {
+  const t = useTranslations('HomePage');
+  const tFeatured = useTranslations('FeaturedTools');
+
+  if (!tool) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900 shadow-sm">
+      <div className="flex items-center gap-2 mb-4">
+        <Zap className="h-5 w-5 text-purple-500 fill-purple-500" />
+        <h3 className="font-semibold text-zinc-900 dark:text-white">
+          {t('toolOfTheWeek')}
+        </h3>
+      </div>
+
+      <div className="relative aspect-video w-full overflow-hidden rounded-lg bg-zinc-100 dark:bg-zinc-800 mb-4">
+        {tool.image ? (
+            <Image
+                src={tool.image}
+                alt={tool.title}
+                fill
+                className="object-cover"
+            />
+        ) : (
+             <div className="flex h-full items-center justify-center text-zinc-400 font-bold text-2xl">
+                {tool.title.substring(0, 2)}
+             </div>
+        )}
+      </div>
+
+      <h4 className="text-lg font-bold text-zinc-900 dark:text-white mb-2">
+        <Link href={`/tools/${tool.slug}`} className="hover:text-purple-600 transition-colors">
+            {tool.title}
+        </Link>
+      </h4>
+
+      <div className="mb-3">
+         <Rating rating={tool.rating} size="h-4 w-4" textClassName="text-sm font-medium text-zinc-700 dark:text-zinc-300" />
+      </div>
+
+      <p className="text-sm text-zinc-600 dark:text-zinc-400 mb-4 line-clamp-3">
+        {tool.description}
+      </p>
+
+      <Link
+        href={`/tools/${tool.slug}`}
+        className="flex w-full items-center justify-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        {tFeatured('checkItOut')} <ArrowRight className="h-4 w-4" />
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR implements the 'Tool of the Week' sidebar widget as requested in Issue #210.

Key Changes:
- Added `ToolOfTheWeekSidebar.tsx` component.
- Modified `src/app/[locale]/blog/[slug]/page.tsx` to insert the widget in the sidebar, specifically below the Table of Contents/Share buttons and above Recent Posts.
- Utilized existing `getToolOfTheWeek` function from `src/lib/tools.ts`.
- Verified the implementation with a Playwright script and screenshot.
- Ensured responsiveness and dark mode compatibility.

---
*PR created automatically by Jules for task [14870027493796703018](https://jules.google.com/task/14870027493796703018) started by @yuga-hashimoto*