### PR TITLE
Publish 'Best Open Source AI Models 2026' article (JA)

### DIFF
--- a/content/posts/ja/best-open-source-ai-models-2026.md
+++ b/content/posts/ja/best-open-source-ai-models-2026.md
@@ -1,7 +1,7 @@
 ---
 title: '2026年版 最強オープンソースAIモデル（LLM）8選'
 slug: 'best-open-source-ai-models-2026'
-date: '2026-06-15'
+date: '2026-02-21'
 author: 'AI Tool Navigator 編集部'
 excerpt: '2026年、オープンソースAIはGPT-5に匹敵する性能へ。DeepSeek V4、Llama 5、Qwen 3など、ローカルで動作する最新の最強モデルを徹底比較します。'
 tags: ['AI', 'LLM', 'オープンソース', '機械学習', '生成AI', 'DeepSeek', 'Llama']


### PR DESCRIPTION
This PR updates the publication date of the Japanese blog post "Best Open Source AI Models 2026" to make it current (Feb 21, 2026) instead of a future date (June 15, 2026). This effectively "publishes" the draft. The content was verified to be complete and includes links to 8 open-source models including DeepSeek V4 and Llama 5.

---
*PR created automatically by Jules for task [9190341705492290785](https://jules.google.com/task/9190341705492290785) started by @yuga-hashimoto*