### PR TITLE
perf: Reduce unused CSS in Tailwind build

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@source "../**";
+@source "../**/*.{js,ts,jsx,tsx,mdx}";
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
Restrict Tailwind CSS scanning to specific source file extensions (`js`, `ts`, `jsx`, `tsx`, `mdx`) in `src/app/globals.css`. This prevents scanning of non-code files (images, binaries, etc.) in the `src` directory, reducing the generation of unused CSS classes and potentially improving build performance.

---
*PR created automatically by Jules for task [11380549927476054820](https://jules.google.com/task/11380549927476054820) started by @yuga-hashimoto*