### PR TITLE
Refine and Coordinate Exit Intent Newsletter Popup

### DIFF
--- a/src/components/ExitIntentPopup.tsx
+++ b/src/components/ExitIntentPopup.tsx
@@ -39,7 +39,12 @@ export default function ExitIntentPopup() {
 
     const handleMouseLeave = (e: MouseEvent) => {
       if (e.clientY <= 0) {
+        // Double check subscription status before showing
+        if (localStorage.getItem('newsletter_subscribed')) {
+          return;
+        }
         setIsVisible(true);
+        window.dispatchEvent(new CustomEvent('exit-intent-triggered'));
       }
     };
 

--- a/src/components/NewsletterPopup.tsx
+++ b/src/components/NewsletterPopup.tsx
@@ -42,10 +42,23 @@ export default function NewsletterPopup() {
 
     // Show popup after a small delay (e.g., 3 seconds)
     const timer = setTimeout(() => {
+      // Double check subscription status before showing
+      if (localStorage.getItem('newsletter_subscribed')) {
+        return;
+      }
       setIsVisible(true);
     }, 3000);
 
-    return () => clearTimeout(timer);
+    const handleExitIntentTriggered = () => {
+      setIsVisible(false);
+    };
+
+    window.addEventListener('exit-intent-triggered', handleExitIntentTriggered);
+
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener('exit-intent-triggered', handleExitIntentTriggered);
+    };
   }, [isClient]);
 
   const handleClose = () => {


### PR DESCRIPTION
Refined the coordination between the `ExitIntentPopup` and `NewsletterPopup` to prevent overlapping and ensure a better user experience.
- Implemented a custom event `exit-intent-triggered` to allow `ExitIntentPopup` to signal `NewsletterPopup` to close.
- Added dynamic checks for `newsletter_subscribed` in `localStorage` to prevent popups from appearing if the user has already subscribed during the current session.
- Verified the behavior with Playwright scripts covering overlap scenarios and subscription synchronization.

---
*PR created automatically by Jules for task [21616525784549129](https://jules.google.com/task/21616525784549129) started by @yuga-hashimoto*