### PR TITLE
Add Top Picks section to homepage

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -100,6 +100,10 @@
       "promoted": "Featured",
       "checkItOut": "Check it out"
   },
+  "TopPicks": {
+    "title": "Top Picks",
+    "description": "Our highest-rated AI tools, curated for performance and value."
+  },
   "ToolPage": {
     "backToTools": "Back to Tools",
     "lastUpdated": "Last updated",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -92,6 +92,10 @@
       "promoted": "注目",
       "checkItOut": "チェックする"
   },
+  "TopPicks": {
+    "title": "トップピック",
+    "description": "高評価のAIツールを厳選しました。"
+  },
   "ToolPage": {
     "backToTools": "ツール一覧に戻る",
     "lastUpdated": "最終更新日",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,6 +4,7 @@ import { ToolCard } from "@/components/ToolCard";
 import { FeaturedTools } from "@/components/FeaturedTools";
 import { FeaturedCarousel } from "@/components/FeaturedCarousel";
 import { SponsoredTools } from "@/components/SponsoredTools";
+import { TopPicks } from "@/components/TopPicks";
 import { ToolOfTheWeek } from "@/components/ToolOfTheWeek";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { Link } from "@/i18n/routing";
@@ -43,6 +44,11 @@ export default async function Home({
   const toolOfTheWeek = getToolOfTheWeek(locale);
   const editorsChoiceSlugs = ['speechify', 'mixo', 'copy-ai', 'basedlabs', 'homesage'];
   const editorsChoiceTools = tools.filter(tool => editorsChoiceSlugs.includes(tool.slug));
+
+  const topPicks = tools
+    .filter(t => !t.sponsored && !t.promoted && !t.featured && t.slug !== toolOfTheWeek?.slug)
+    .sort((a, b) => b.rating - a.rating)
+    .slice(0, 6);
 
   return (
     <div className="bg-white dark:bg-black min-h-screen transition-colors duration-300">
@@ -99,6 +105,9 @@ export default async function Home({
 
             {/* Featured Tools Section */}
             <FeaturedTools tools={tools} />
+
+            {/* Top Picks Section */}
+            <TopPicks tools={topPicks} />
 
             {/* Editor's Choice Section */}
             {editorsChoiceTools.length > 0 && (

--- a/src/components/TopPicks.tsx
+++ b/src/components/TopPicks.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { ToolMetadata } from '@/lib/tools';
+import { ToolCard } from '@/components/ToolCard';
+import { useTranslations } from 'next-intl';
+import { Trophy } from 'lucide-react';
+
+interface TopPicksProps {
+  tools: ToolMetadata[];
+}
+
+export function TopPicks({ tools }: TopPicksProps) {
+  const t = useTranslations('TopPicks');
+
+  if (tools.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-16">
+      <div className="flex items-center gap-2 mb-6">
+        <Trophy className="h-6 w-6 text-yellow-500" />
+        <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+          {t('title')}
+        </h2>
+      </div>
+      <p className="mb-8 text-lg text-zinc-600 dark:text-zinc-400">
+        {t('description')}
+      </p>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {tools.map((tool) => (
+          <div key={tool.slug} className="flex flex-col h-full">
+            <ToolCard tool={tool} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a "Top Picks" section to the homepage. The section displays the top 6 highest-rated tools that are not sponsored, promoted, or featured elsewhere on the page, ensuring a curated list of organic top performers.

Changes include:
- New `TopPicks` component in `src/components/TopPicks.tsx`.
- Updated `src/app/[locale]/page.tsx` to include the new section and logic for selecting top picks.
- Localization updates in `messages/en.json` and `messages/ja.json`.


---
*PR created automatically by Jules for task [2537926508346231667](https://jules.google.com/task/2537926508346231667) started by @yuga-hashimoto*