### PR TITLE
Implement Lazy Loading for Youtube Embeds

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import remarkDirective from "remark-directive";
 import { remarkRelatedPost } from "@/lib/remark-related-post";
 import { remarkComparisonTable } from "@/lib/remark-comparison-table";
+import { remarkYoutube } from "@/lib/remark-youtube";
 import rehypeSlug from "rehype-slug";
 import { routing, Link } from "@/i18n/routing";
 import { Calendar, User, Clock } from "lucide-react";
@@ -18,6 +19,7 @@ import { ShareButtons } from "@/components/ShareButtons";
 import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { RelatedPost } from "@/components/RelatedPost";
 import { ComparisonTable } from "@/components/ComparisonTable";
+import { YouTubeEmbed } from "@/components/YouTubeEmbed";
 import { generateBlogPostSchema } from "@/lib/schema";
 import { getToolOfTheWeek, getToolBySlug, ToolMetadata } from "@/lib/tools";
 import { ToolOfTheWeekSidebar } from "@/components/ToolOfTheWeekSidebar";
@@ -131,6 +133,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
       return <ComparisonTable tools={toolsData} />;
     },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    'youtube-embed': (props: any) => {
+        return <YouTubeEmbed {...props} />;
+    },
   };
 
   return (
@@ -192,7 +198,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
                     <div className="prose prose-lg prose-zinc dark:prose-invert">
                         <ReactMarkdown
-                            remarkPlugins={[remarkGfm, remarkDirective, remarkRelatedPost, remarkComparisonTable]}
+                            remarkPlugins={[remarkGfm, remarkDirective, remarkRelatedPost, remarkComparisonTable, remarkYoutube]}
                             rehypePlugins={[rehypeSlug]}
                             components={components}
                         >

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -2,6 +2,9 @@ import { getToolBySlug, getToolSlugs, getRelatedTools } from "@/lib/tools";
 import { getRelatedPosts } from "@/lib/posts";
 import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkDirective from "remark-directive";
+import { remarkYoutube } from "@/lib/remark-youtube";
 import { ExternalLink, BadgeCheck, Calendar } from "lucide-react";
 import { Metadata } from "next";
 import { ToolCard } from "@/components/ToolCard";
@@ -16,6 +19,7 @@ import { getCategorySlug } from "@/lib/breadcrumbs";
 import { CopyLinkButton } from "@/components/CopyLinkButton";
 import { ShareButtons } from "@/components/ShareButtons";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { YouTubeEmbed } from "@/components/YouTubeEmbed";
 
 export async function generateStaticParams() {
   const slugs = getToolSlugs();
@@ -87,6 +91,13 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
 
   breadcrumbItems.push({ label: metadata.title });
 
+  const components = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    'youtube-embed': (props: any) => {
+        return <YouTubeEmbed {...props} />;
+    },
+  };
+
   return (
     <div className="bg-white dark:bg-black min-h-screen py-12 transition-colors duration-300">
       <script
@@ -155,7 +166,13 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                 )}
 
                 <div className="mt-12 prose prose-zinc dark:prose-invert max-w-none">
-                    <ReactMarkdown>{content}</ReactMarkdown>
+                    <ReactMarkdown
+                        remarkPlugins={[remarkGfm, remarkDirective, remarkYoutube]}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        components={components as any}
+                    >
+                        {content}
+                    </ReactMarkdown>
                 </div>
 
                 <div className="mt-12 pt-8 border-t border-zinc-200 dark:border-zinc-800">

--- a/src/components/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { Play } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface YouTubeEmbedProps {
+  videoId: string;
+  title?: string;
+  className?: string;
+}
+
+export function YouTubeEmbed({ videoId, title = "YouTube video", className }: YouTubeEmbedProps) {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  if (!videoId) return null;
+
+  return (
+    <div
+      className={cn(
+        "relative w-full overflow-hidden rounded-xl bg-gray-100 shadow-lg aspect-video",
+        className
+      )}
+    >
+      {!isPlaying ? (
+        <button
+          onClick={() => setIsPlaying(true)}
+          className="group relative flex h-full w-full items-center justify-center"
+          aria-label={`Play ${title}`}
+        >
+          {/* Thumbnail */}
+          <img
+            src={`https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`}
+            alt={title}
+            className="absolute inset-0 h-full w-full object-cover transition-opacity duration-300 group-hover:opacity-90"
+            loading="lazy"
+          />
+
+          {/* Play Button Overlay */}
+          <div className="relative z-10 flex h-16 w-16 items-center justify-center rounded-full bg-white/90 shadow-xl transition-transform duration-300 group-hover:scale-110">
+            <Play className="h-6 w-6 fill-black text-black ml-1" />
+          </div>
+
+          {/* Hover Overlay */}
+          <div className="absolute inset-0 bg-black/10 transition-colors duration-300 group-hover:bg-black/20" />
+        </button>
+      ) : (
+        <iframe
+          src={`https://www.youtube.com/embed/${videoId}?autoplay=1`}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="absolute inset-0 h-full w-full border-0"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/lib/remark-youtube.ts
+++ b/src/lib/remark-youtube.ts
@@ -1,0 +1,26 @@
+import { visit } from 'unist-util-visit';
+
+export function remarkYoutube() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (tree: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    visit(tree, (node: any) => {
+      if (
+        node.type === 'textDirective' ||
+        node.type === 'leafDirective'
+      ) {
+        if (node.name !== 'youtube') return;
+
+        const data = node.data || (node.data = {});
+        const attributes = node.attributes || {};
+        const videoId = attributes.id;
+        const title = attributes.title;
+
+        if (!videoId) return;
+
+        data.hName = 'youtube-embed';
+        data.hProperties = { videoId, title };
+      }
+    });
+  };
+}


### PR DESCRIPTION
This PR implements lazy loading for YouTube embeds to improve performance. It introduces a new `YouTubeEmbed` component that renders a lightweight thumbnail and play button initially, only loading the heavy iframe upon user interaction. A new `remark-youtube` plugin was created to support the `::youtube{id="..."}` syntax in Markdown files. Both Blog and Tool pages were updated to utilize this new functionality.

---
*PR created automatically by Jules for task [6573178077803493707](https://jules.google.com/task/6573178077803493707) started by @yuga-hashimoto*