### PR TITLE
Add Breadcrumb Schema to all pages

### DIFF
--- a/dev_output.log
+++ b/dev_output.log
@@ -13,6 +13,13 @@ You can learn more, including how to opt-out if you'd not like to participate in
 https://nextjs.org/telemetry
 
 ⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
-✓ Ready in 2.2s
-○ Compiling /[locale]/blog/[slug] ...
- GET /en/blog/test-comparison-table 200 in 10.1s (compile: 8.3s, proxy.ts: 204ms, generate-params: 1326ms, render: 1598ms)
+✓ Ready in 2.7s
+○ Compiling /[locale]/about ...
+ GET /en/about 200 in 7.8s (compile: 6.6s, proxy.ts: 202ms, render: 1005ms)
+✓ Compiled in 111ms
+ GET /en/about 200 in 453ms (compile: 120ms, proxy.ts: 11ms, render: 321ms)
+ GET /en/about 200 in 271ms (compile: 36ms, proxy.ts: 7ms, render: 227ms)
+ GET /en/submit 200 in 2.7s (compile: 2.4s, proxy.ts: 7ms, render: 290ms)
+ GET /en/privacy 200 in 1662ms (compile: 1364ms, proxy.ts: 8ms, render: 290ms)
+ GET /en/blog 200 in 2.5s (compile: 2.0s, proxy.ts: 7ms, render: 524ms)
+ GET /en/tools/chatgpt 200 in 4.1s (compile: 3.2s, proxy.ts: 6ms, generate-params: 1451ms, render: 888ms)

--- a/messages/en.json
+++ b/messages/en.json
@@ -201,7 +201,13 @@
     "search": "Search",
     "security": "Security",
     "voice": "Voice",
-    "design": "Design"
+    "design": "Design",
+    "about": "About",
+    "advertise": "Advertise",
+    "privacy": "Privacy",
+    "sponsor": "Sponsor",
+    "submit": "Submit Tool",
+    "terms": "Terms"
   },
   "AboutPage": {
     "title": "About AI Tool Navigator",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -193,7 +193,13 @@
     "search": "検索",
     "security": "セキュリティ",
     "voice": "音声",
-    "design": "デザイン"
+    "design": "デザイン",
+    "about": "About",
+    "advertise": "広告",
+    "privacy": "プライバシー",
+    "sponsor": "スポンサー",
+    "submit": "ツールを送信",
+    "terms": "利用規約"
   },
   "AboutPage": {
     "title": "About AI Tool Navigator",

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,4 +1,6 @@
 import { getTranslations } from 'next-intl/server';
+import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -24,12 +26,25 @@ export default async function AboutPage({
   // We need to await params to satisfy Next.js 15+ requirements,
   // even though we don't strictly need 'locale' if we use getTranslations w/o locale
   // but it's good practice.
-  await params;
+  const { locale } = await params;
   const t = await getTranslations('AboutPage');
+  const tBreadcrumbs = await getTranslations('Breadcrumbs');
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: tBreadcrumbs('home'), href: '/' },
+    { label: tBreadcrumbs('about') },
+  ];
+
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
 
   return (
     <div className="bg-white dark:bg-black min-h-screen transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
+        <Breadcrumbs items={breadcrumbItems} />
         <div className="mx-auto max-w-2xl text-center mb-16">
           <h1 className="text-4xl font-extrabold tracking-tight text-zinc-900 sm:text-6xl dark:text-zinc-50">
             {t('title')}

--- a/src/app/[locale]/advertise/page.tsx
+++ b/src/app/[locale]/advertise/page.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -16,10 +19,25 @@ export async function generateMetadata({
   };
 }
 
-export default function AdvertisePage() {
+export default async function AdvertisePage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const tBreadcrumbs = await getTranslations('Breadcrumbs');
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: tBreadcrumbs('home'), href: '/' },
+    { label: tBreadcrumbs('advertise') },
+  ];
+
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="max-w-7xl mx-auto">
+        <Breadcrumbs items={breadcrumbItems} />
         <div className="text-center">
           <h2 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
             Sponsor AI Tools Navigator

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -18,7 +18,7 @@ import { ShareButtons } from "@/components/ShareButtons";
 import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { RelatedPost } from "@/components/RelatedPost";
 import { ComparisonTable } from "@/components/ComparisonTable";
-import { generateBlogPostSchema } from "@/lib/schema";
+import { generateBlogPostSchema, generateBreadcrumbSchema } from "@/lib/schema";
 import { getToolOfTheWeek, getToolBySlug, ToolMetadata } from "@/lib/tools";
 import { ToolOfTheWeekSidebar } from "@/components/ToolOfTheWeekSidebar";
 
@@ -92,6 +92,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     { label: metadata.title },
   ];
 
+  const breadcrumbSchema = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   // Fetch recent posts
   const allPosts = getAllPosts(locale);
   const recentPosts = allPosts
@@ -138,6 +140,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
       />
       <ReadingProgressBar />
       <div className="mx-auto max-w-7xl px-6 lg:px-8">

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { ArticleCard } from "@/components/ArticleCard";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Blog - AI Tool Navigator",
@@ -24,8 +25,14 @@ export default async function BlogPage({
     { label: tBreadcrumbs('blog') },
   ];
 
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-white dark:bg-black min-h-screen py-24 sm:py-32 transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <Breadcrumbs items={breadcrumbItems} />
         <div className="mx-auto max-w-2xl text-center mb-16">

--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { CATEGORY_MAPPINGS } from "@/lib/categories";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateStaticParams() {
   return Object.keys(CATEGORY_MAPPINGS).map((slug) => ({
@@ -90,8 +91,14 @@ export default async function CategoryPage({
     { label: tBreadcrumbs(slug as any) },
   ];
 
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-white dark:bg-black min-h-screen transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
         <Breadcrumbs items={breadcrumbItems} />
         <div className="mx-auto max-w-2xl text-center mb-16">

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -4,6 +4,7 @@ import { Metadata } from "next";
 import Link from 'next/link';
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { getTranslations } from "next-intl/server";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -34,8 +35,14 @@ export default async function ComparePage({
     { label: tBreadcrumbs('compare') },
   ];
 
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-white dark:bg-black min-h-screen transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
         <Breadcrumbs items={breadcrumbItems} />
         <div className="mx-auto max-w-2xl text-center mb-16">

--- a/src/app/[locale]/deals/page.tsx
+++ b/src/app/[locale]/deals/page.tsx
@@ -3,6 +3,7 @@ import { ToolGrid } from "@/components/ToolGrid";
 import { getTranslations } from 'next-intl/server';
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { Suspense } from 'react';
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -36,8 +37,14 @@ export default async function DealsPage({
     { label: tBreadcrumbs('deals') },
   ];
 
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-white dark:bg-black min-h-screen transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
         <Breadcrumbs items={breadcrumbItems} />
         <div className="mx-auto max-w-2xl text-center mb-16">

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -16,10 +19,25 @@ export async function generateMetadata({
   };
 }
 
-export default function PrivacyPage() {
+export default async function PrivacyPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const tBreadcrumbs = await getTranslations('Breadcrumbs');
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: tBreadcrumbs('home'), href: '/' },
+    { label: tBreadcrumbs('privacy') },
+  ];
+
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-background min-h-screen py-12 transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-4xl px-6 lg:px-8">
+        <Breadcrumbs items={breadcrumbItems} />
         <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl mb-8">
           Privacy Policy
         </h1>

--- a/src/app/[locale]/sponsor/page.tsx
+++ b/src/app/[locale]/sponsor/page.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -16,10 +19,25 @@ export async function generateMetadata({
   };
 }
 
-export default function SponsorshipPage() {
+export default async function SponsorshipPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const tBreadcrumbs = await getTranslations('Breadcrumbs');
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: tBreadcrumbs('home'), href: '/' },
+    { label: tBreadcrumbs('sponsor') },
+  ];
+
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-white dark:bg-black min-h-screen text-zinc-900 dark:text-zinc-50 transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-4xl px-6 py-24 sm:py-32 lg:px-8">
+        <Breadcrumbs items={breadcrumbItems} />
         <div className="text-center mb-16">
           <h1 className="text-4xl font-extrabold tracking-tight sm:text-6xl">
             Partner with AI Tool Navigator

--- a/src/app/[locale]/submit/page.tsx
+++ b/src/app/[locale]/submit/page.tsx
@@ -1,5 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 import { SubmitForm } from '@/components/SubmitForm';
+import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -24,10 +26,23 @@ export default async function SubmitPage({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'SubmitPage' });
+  const tBreadcrumbs = await getTranslations('Breadcrumbs');
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: tBreadcrumbs('home'), href: '/' },
+    { label: tBreadcrumbs('submit') },
+  ];
+
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
 
   return (
     <div className="bg-white dark:bg-black min-h-screen py-16 sm:py-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <Breadcrumbs items={breadcrumbItems} />
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
             {t('title')}

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
 
 export async function generateMetadata({
   params
@@ -16,10 +19,25 @@ export async function generateMetadata({
   };
 }
 
-export default function TermsPage() {
+export default async function TermsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const tBreadcrumbs = await getTranslations('Breadcrumbs');
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: tBreadcrumbs('home'), href: '/' },
+    { label: tBreadcrumbs('terms') },
+  ];
+
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-background min-h-screen py-12 transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="mx-auto max-w-4xl px-6 lg:px-8">
+        <Breadcrumbs items={breadcrumbItems} />
         <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl mb-8">
           Terms of Service
         </h1>

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { ToolCard } from "@/components/ToolCard";
 import { Rating } from "@/components/Rating";
 import { ArticleCard } from "@/components/ArticleCard";
 import { getTranslations } from "next-intl/server";
-import { generateToolSchema } from "@/lib/schema";
+import { generateToolSchema, generateBreadcrumbSchema } from "@/lib/schema";
 import { ProsConsSection } from "@/components/ProsConsSection";
 import { RatingBreakdown } from "@/components/RatingBreakdown";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
@@ -87,11 +87,17 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
 
   breadcrumbItems.push({ label: metadata.title });
 
+  const breadcrumbSchema = generateBreadcrumbSchema(breadcrumbItems, locale);
+
   return (
     <div className="bg-white dark:bg-black min-h-screen py-12 transition-colors duration-300">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
       />
       <div className="mx-auto max-w-4xl px-6 lg:px-8">
         <Breadcrumbs items={breadcrumbItems} />

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,5 +1,6 @@
 import { Tool } from "@/lib/tools";
 import { Post } from "@/lib/posts";
+import { BreadcrumbItem } from "@/components/Breadcrumbs";
 
 const APPLICATION_CATEGORY_MAP: Record<string, string> = {
   "Video Generation": "MultimediaApplication",
@@ -121,4 +122,35 @@ export function generateBlogPostSchema(post: Post, url: string) {
   }
 
   return schema;
+}
+
+export function generateBreadcrumbSchema(items: BreadcrumbItem[], locale: string) {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://ai-tool-navigator.vercel.app';
+
+  const itemListElement = items.map((item, index) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const schemaItem: any = {
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.label,
+    };
+
+    if (item.href) {
+      // If href is present, construct full URL
+      const path = item.href === '/' ? '' : item.href;
+      // Ensure path starts with / if not empty
+      const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+      // Note: next-intl routing typically handles locale prefixing in Link component,
+      // but for schema URL we need absolute URL including locale.
+      schemaItem.item = `${siteUrl}/${locale}${normalizedPath === '/' ? '' : normalizedPath}`;
+    }
+
+    return schemaItem;
+  });
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement,
+  };
 }


### PR DESCRIPTION
Added BreadcrumbList JSON-LD schema to all pages to improve SEO.
Updated translation files (en, ja) with new keys for static pages in Breadcrumbs namespace.
Added Breadcrumbs component and schema to About, Advertise, Privacy, Sponsor, Submit, and Terms pages.
Updated existing pages (Blog, Category, Compare, Deals, Tool Detail) to include Breadcrumb Schema.
Implemented generateBreadcrumbSchema utility in src/lib/schema.ts.

---
*PR created automatically by Jules for task [9298502380915645930](https://jules.google.com/task/9298502380915645930) started by @yuga-hashimoto*