### PR TITLE
Add ErrorBoundary to ToolGrid component

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -77,7 +77,8 @@
   },
   "ToolGrid": {
       "searchPlaceholder": "Search tools...",
-      "all": "All"
+      "all": "All",
+      "error": "Something went wrong while loading the tools."
   },
   "ToolCard": {
       "compare": "Compare",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -69,7 +69,8 @@
   },
   "ToolGrid": {
       "searchPlaceholder": "ツールを検索...",
-      "all": "すべて"
+      "all": "すべて",
+      "error": "ツールの読み込み中にエラーが発生しました。"
   },
   "ToolCard": {
       "compare": "比較",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false
+  };
+
+  public static getDerivedStateFromError(_: Error): State {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return this.props.fallback || <h1>Sorry.. there was an error</h1>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/ToolGrid.tsx
+++ b/src/components/ToolGrid.tsx
@@ -7,13 +7,30 @@ import { cn } from '@/lib/utils';
 import { Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
+import { ErrorBoundary } from './ErrorBoundary';
 
 interface ToolGridProps {
   tools: ToolMetadata[];
   hideSearch?: boolean;
 }
 
-export function ToolGrid({ tools, hideSearch }: ToolGridProps) {
+export function ToolGrid(props: ToolGridProps) {
+  const t = useTranslations('ToolGrid');
+
+  return (
+    <ErrorBoundary
+      fallback={
+        <div className="py-12 text-center">
+            <p className="text-red-500">{t('error')}</p>
+        </div>
+      }
+    >
+      <ToolGridContent {...props} />
+    </ErrorBoundary>
+  );
+}
+
+function ToolGridContent({ tools, hideSearch }: ToolGridProps) {
   const searchParams = useSearchParams();
   const [selectedCategory, setSelectedCategory] = useState<string>('All');
   const [searchQuery, setSearchQuery] = useState<string>(searchParams.get('search') || '');


### PR DESCRIPTION
Added an `ErrorBoundary` component to `src/components/ToolGrid.tsx` to prevent the application from crashing if the `ToolGrid` component fails. The error boundary displays a localized error message.

---
*PR created automatically by Jules for task [14160170086436227227](https://jules.google.com/task/14160170086436227227) started by @yuga-hashimoto*