### PR TITLE
Add Google AdSense placeholder to blog post sidebar

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { ComparisonTable } from "@/components/ComparisonTable";
 import { generateBlogPostSchema, generateBreadcrumbSchema } from "@/lib/schema";
 import { getToolOfTheWeek, getToolBySlug, ToolMetadata } from "@/lib/tools";
 import { ToolOfTheWeekSidebar } from "@/components/ToolOfTheWeekSidebar";
+import { GoogleAdsensePlaceholder } from "@/components/GoogleAdsensePlaceholder";
 
 export async function generateStaticParams() {
   const params = [];
@@ -223,6 +224,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                             />
                         </div>
                     </div>
+
+                    <GoogleAdsensePlaceholder />
 
                     <ToolOfTheWeekSidebar tool={toolOfTheWeek} />
 

--- a/src/components/GoogleAdsensePlaceholder.tsx
+++ b/src/components/GoogleAdsensePlaceholder.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export function GoogleAdsensePlaceholder() {
+  return (
+    <div className="flex w-full flex-col items-center justify-center rounded-2xl border border-zinc-200 bg-gray-50 p-6 text-center dark:border-zinc-800 dark:bg-zinc-900 shadow-sm">
+      <div className="flex h-[250px] w-full max-w-[300px] items-center justify-center rounded border border-dashed border-zinc-300 bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800">
+        <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
+          Google AdSense
+        </span>
+      </div>
+      <span className="mt-2 text-xs text-zinc-400 dark:text-zinc-500 uppercase tracking-wider">
+        Advertisement
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
This change adds a visual placeholder for Google AdSense to the blog post sidebar. It introduces a new `GoogleAdsensePlaceholder` component and places it strategically in the sidebar layout. The placeholder is responsive and styled to match the site's theme (light/dark mode). The environment was also updated to resolve linting issues.

---
*PR created automatically by Jules for task [6243602471944630650](https://jules.google.com/task/6243602471944630650) started by @yuga-hashimoto*