### PR TITLE
feat: add support page with stripe donation placeholder

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -211,7 +211,14 @@
     "privacy": "Privacy",
     "sponsor": "Sponsor",
     "submit": "Submit Tool",
-    "terms": "Terms"
+    "terms": "Terms",
+    "support": "Support Us"
+  },
+  "SupportPage": {
+    "title": "Support Us",
+    "description": "Help us continue to provide unbiased AI tool reviews and comparisons.",
+    "intro": "If you find our content helpful, please consider supporting us. Your contributions help us cover server costs and dedicate more time to researching and testing new AI tools.",
+    "donate_button": "Donate via Stripe"
   },
   "AboutPage": {
     "title": "About AI Tool Navigator",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -203,7 +203,14 @@
     "privacy": "プライバシー",
     "sponsor": "スポンサー",
     "submit": "ツールを送信",
-    "terms": "利用規約"
+    "terms": "利用規約",
+    "support": "サポート"
+  },
+  "SupportPage": {
+    "title": "サポート",
+    "description": "公平なAIツールレビューと比較を提供し続けるために、ご支援をお願いします。",
+    "intro": "私たちのコンテンツがお役に立ちましたら、サポートをご検討ください。皆様の寄付は、サーバー費用や新しいAIツールの調査・テストに充てられます。",
+    "donate_button": "Stripeで寄付する"
   },
   "AboutPage": {
     "title": "About AI Tool Navigator",

--- a/src/app/[locale]/support/page.tsx
+++ b/src/app/[locale]/support/page.tsx
@@ -1,0 +1,70 @@
+import { getTranslations } from 'next-intl/server';
+import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
+import { generateBreadcrumbSchema } from "@/lib/schema";
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({locale, namespace: 'SupportPage'});
+  return {
+    title: t('title'),
+    description: t('description'),
+    alternates: {
+      canonical: `/${locale}/support`,
+    }
+  };
+}
+
+export default async function SupportPage({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params;
+  const t = await getTranslations('SupportPage');
+  const tBreadcrumbs = await getTranslations('Breadcrumbs');
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: tBreadcrumbs('home'), href: '/' },
+    { label: tBreadcrumbs('support') },
+  ];
+
+  const jsonLd = generateBreadcrumbSchema(breadcrumbItems, locale);
+
+  return (
+    <div className="bg-white dark:bg-black min-h-screen transition-colors duration-300">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
+        <Breadcrumbs items={breadcrumbItems} />
+        <div className="mx-auto max-w-2xl text-center mb-16">
+          <h1 className="text-4xl font-extrabold tracking-tight text-zinc-900 sm:text-6xl dark:text-zinc-50">
+            {t('title')}
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-zinc-600 dark:text-zinc-400">
+            {t('description')}
+          </p>
+        </div>
+
+        <div className="mx-auto max-w-3xl text-center">
+             <p className="text-lg leading-8 text-zinc-600 dark:text-zinc-300 mb-10">
+               {t('intro')}
+             </p>
+
+             <a
+               href="#"
+               className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 inline-block"
+               aria-disabled="true"
+             >
+               {t('donate_button')}
+             </a>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Added a new 'Support Us' page (`src/app/[locale]/support/page.tsx`) that includes a title, description, and a placeholder button for a Stripe donation link.

Changes:
- `src/app/[locale]/support/page.tsx`: New page component using `SupportPage` translations.
- `messages/en.json`: Added `SupportPage` namespace and `Breadcrumbs.support`.
- `messages/ja.json`: Added `SupportPage` namespace and `Breadcrumbs.support`.

Verification:
- Manually verified using Playwright scripts for both English and Japanese versions to ensure correct rendering of title, text, and button.
- Linting passed.


---
*PR created automatically by Jules for task [17974329851250211321](https://jules.google.com/task/17974329851250211321) started by @yuga-hashimoto*