### PR TITLE
Implement dynamic Google AdSense placement

### DIFF
--- a/dev_output.log
+++ b/dev_output.log
@@ -13,13 +13,8 @@ You can learn more, including how to opt-out if you'd not like to participate in
 https://nextjs.org/telemetry
 
 ⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
-✓ Ready in 2.7s
-○ Compiling /[locale]/about ...
- GET /en/about 200 in 7.8s (compile: 6.6s, proxy.ts: 202ms, render: 1005ms)
-✓ Compiled in 111ms
- GET /en/about 200 in 453ms (compile: 120ms, proxy.ts: 11ms, render: 321ms)
- GET /en/about 200 in 271ms (compile: 36ms, proxy.ts: 7ms, render: 227ms)
- GET /en/submit 200 in 2.7s (compile: 2.4s, proxy.ts: 7ms, render: 290ms)
- GET /en/privacy 200 in 1662ms (compile: 1364ms, proxy.ts: 8ms, render: 290ms)
- GET /en/blog 200 in 2.5s (compile: 2.0s, proxy.ts: 7ms, render: 524ms)
- GET /en/tools/chatgpt 200 in 4.1s (compile: 3.2s, proxy.ts: 6ms, generate-params: 1451ms, render: 888ms)
+✓ Ready in 2.6s
+○ Compiling /[locale]/blog/[slug] ...
+ GET /en/blog/top-5-ai-video-generators-2026 200 in 11.9s (compile: 9.9s, proxy.ts: 218ms, generate-params: 1375ms, render: 1863ms)
+○ Compiling /[locale] ...
+ GET /en 200 in 5.7s (compile: 4.7s, proxy.ts: 18ms, render: 935ms)

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import remarkDirective from "remark-directive";
 import { remarkRelatedPost } from "@/lib/remark-related-post";
 import { remarkComparisonTable } from "@/lib/remark-comparison-table";
 import rehypeSlug from "rehype-slug";
+import rehypeGoogleAdsense from "@/lib/rehype-google-adsense";
 import { routing, Link } from "@/i18n/routing";
 import { Calendar, User, Clock } from "lucide-react";
 import { Metadata } from "next";
@@ -21,7 +22,7 @@ import { ComparisonTable } from "@/components/ComparisonTable";
 import { generateBlogPostSchema, generateBreadcrumbSchema } from "@/lib/schema";
 import { getToolOfTheWeek, getToolBySlug, ToolMetadata } from "@/lib/tools";
 import { ToolOfTheWeekSidebar } from "@/components/ToolOfTheWeekSidebar";
-import { GoogleAdsensePlaceholder } from "@/components/GoogleAdsensePlaceholder";
+import { GoogleAdsense } from "@/components/GoogleAdsense";
 
 export async function generateStaticParams() {
   const params = [];
@@ -134,6 +135,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
       return <ComparisonTable tools={toolsData} />;
     },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    'google-adsense-slot': (props: any) => {
+      return <GoogleAdsense {...props} className="my-8" />;
+    },
   };
 
   return (
@@ -200,7 +205,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                     <div className="prose prose-lg prose-zinc dark:prose-invert">
                         <ReactMarkdown
                             remarkPlugins={[remarkGfm, remarkDirective, remarkRelatedPost, remarkComparisonTable]}
-                            rehypePlugins={[rehypeSlug]}
+                            rehypePlugins={[
+                              rehypeSlug,
+                              [rehypeGoogleAdsense, { slot: process.env.NEXT_PUBLIC_ADSENSE_SLOT_BLOG || 'blog' }]
+                            ]}
                             components={components}
                         >
                             {content}
@@ -225,7 +233,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                         </div>
                     </div>
 
-                    <GoogleAdsensePlaceholder />
+                    <GoogleAdsense
+                      slot={process.env.NEXT_PUBLIC_ADSENSE_SLOT_SIDEBAR || 'sidebar'}
+                      className="w-full"
+                    />
 
                     <ToolOfTheWeekSidebar tool={toolOfTheWeek} />
 

--- a/src/components/GoogleAdsense.tsx
+++ b/src/components/GoogleAdsense.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Script from 'next/script';
+import { useEffect } from 'react';
+import { GoogleAdsensePlaceholder } from './GoogleAdsensePlaceholder';
+
+interface GoogleAdsenseProps {
+  slot: string;
+  format?: string;
+  responsive?: string;
+  layout?: string;
+  layoutKey?: string;
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    adsbygoogle: any[];
+  }
+}
+
+export function GoogleAdsense({
+  slot,
+  format = 'auto',
+  responsive = 'true',
+  layout,
+  layoutKey,
+  style,
+  className,
+}: GoogleAdsenseProps) {
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_CLIENT_ID;
+
+  useEffect(() => {
+    if (!clientId) return;
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (err) {
+      console.error('AdSense error:', err);
+    }
+  }, [clientId]);
+
+  if (!clientId) {
+    return (
+      <div className={className} style={style}>
+        <GoogleAdsensePlaceholder />
+      </div>
+    );
+  }
+
+  return (
+    <div className={className} style={{ overflow: 'hidden', ...style }}>
+      <Script
+        id="adsbygoogle-init"
+        strategy="afterInteractive"
+        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${clientId}`}
+        crossOrigin="anonymous"
+      />
+      <ins
+        className="adsbygoogle"
+        style={{ display: 'block' }}
+        data-ad-client={clientId}
+        data-ad-slot={slot}
+        data-ad-format={format}
+        data-full-width-responsive={responsive}
+        data-ad-layout={layout}
+        data-ad-layout-key={layoutKey}
+      />
+    </div>
+  );
+}

--- a/src/components/ToolGrid.tsx
+++ b/src/components/ToolGrid.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
+import { GoogleAdsense } from './GoogleAdsense';
 
 interface ToolGridProps {
   tools: ToolMetadata[];
@@ -81,11 +82,25 @@ export function ToolGrid({ tools, hideSearch, priority = false }: ToolGridProps)
         </div>
 
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {filteredTools.map((tool, index) => (
-                <div key={tool.slug} className="flex flex-col h-full">
-                   <ToolCard tool={tool} priority={priority && index < 4} />
-                </div>
-            ))}
+            {filteredTools.flatMap((tool, index) => {
+                const elements = [
+                    <div key={tool.slug} className="flex flex-col h-full">
+                       <ToolCard tool={tool} priority={priority && index < 4} />
+                    </div>
+                ];
+
+                if ((index + 1) % 9 === 0) {
+                    elements.push(
+                        <div key={`ad-${index}`} className="flex flex-col h-full min-h-[250px] overflow-hidden rounded-2xl border border-zinc-200 bg-gray-50 dark:border-zinc-800 dark:bg-zinc-900/50">
+                             <GoogleAdsense
+                                slot={process.env.NEXT_PUBLIC_ADSENSE_SLOT_GRID || 'grid'}
+                                className="w-full h-full flex items-center justify-center"
+                             />
+                        </div>
+                    );
+                }
+                return elements;
+            })}
         </div>
         {filteredTools.length === 0 && (
             <div className="py-12 text-center">

--- a/src/lib/rehype-google-adsense.ts
+++ b/src/lib/rehype-google-adsense.ts
@@ -1,0 +1,38 @@
+import { visit } from 'unist-util-visit';
+
+interface Options {
+  slot: string;
+  interval?: number;
+}
+
+export default function rehypeGoogleAdsense(options: Options) {
+  const { slot, interval = 4 } = options;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (tree: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    visit(tree, 'root', (node: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const newChildren: any[] = [];
+      let pCount = 0;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      node.children.forEach((child: any) => {
+        newChildren.push(child);
+        if (child.type === 'element' && child.tagName === 'p') {
+          pCount++;
+          if (pCount > 0 && pCount % interval === 0) {
+            newChildren.push({
+              type: 'element',
+              tagName: 'google-adsense-slot',
+              properties: { slot },
+              children: [],
+            });
+          }
+        }
+      });
+
+      node.children = newChildren;
+    });
+  };
+}


### PR DESCRIPTION
- Implemented `GoogleAdsense` component with placeholder fallback.
- Created `rehype-google-adsense` plugin to inject ads every 4 paragraphs in blog posts.
- Updated `ToolGrid` to inject ads every 9 items.
- Configured via `NEXT_PUBLIC_GOOGLE_ADSENSE_CLIENT_ID` and `NEXT_PUBLIC_GOOGLE_ADSENSE_SLOT_ID`.

---
*PR created automatically by Jules for task [2219293277444581006](https://jules.google.com/task/2219293277444581006) started by @yuga-hashimoto*