### PR TITLE
Implement server-side caching for improved performance

### DIFF
--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -13,7 +13,7 @@ export const contentType = 'image/png';
 
 export default async function Image({ params }: { params: Promise<{ slug: string; locale: string }> }) {
   const { slug, locale } = await params;
-  const post = getPostBySlug(slug, locale);
+  const post = await getPostBySlug(slug, locale);
 
   if (!post) {
       return new ImageResponse(

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -19,14 +19,14 @@ import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { RelatedPost } from "@/components/RelatedPost";
 import { ComparisonTable } from "@/components/ComparisonTable";
 import { generateBlogPostSchema, generateBreadcrumbSchema } from "@/lib/schema";
-import { getToolOfTheWeek, getToolBySlug, ToolMetadata } from "@/lib/tools";
+import { getToolOfTheWeek, getAllTools, ToolMetadata } from "@/lib/tools";
 import { ToolOfTheWeekSidebar } from "@/components/ToolOfTheWeekSidebar";
 import { GoogleAdsensePlaceholder } from "@/components/GoogleAdsensePlaceholder";
 
 export async function generateStaticParams() {
   const params = [];
   for (const locale of routing.locales) {
-    const posts = getAllPosts(locale);
+    const posts = await getAllPosts(locale);
     for (const post of posts) {
       params.push({ locale, slug: post.slug });
     }
@@ -38,7 +38,7 @@ export async function generateMetadata(
   { params }: { params: Promise<{ slug: string, locale: string }> }
 ): Promise<Metadata> {
   const { slug, locale } = await params;
-  const post = getPostBySlug(slug, locale);
+  const post = await getPostBySlug(slug, locale);
 
   if (!post) {
     return {
@@ -73,7 +73,7 @@ export async function generateMetadata(
 
 export default async function BlogPostPage({ params }: { params: Promise<{ slug: string, locale: string }> }) {
   const { slug, locale } = await params;
-  const post = getPostBySlug(slug, locale);
+  const post = await getPostBySlug(slug, locale);
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
   const tBlog = await getTranslations('BlogPage');
   const tShare = await getTranslations('ShareButtons');
@@ -96,12 +96,13 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   const breadcrumbSchema = generateBreadcrumbSchema(breadcrumbItems, locale);
 
   // Fetch recent posts
-  const allPosts = getAllPosts(locale);
+  const allPosts = await getAllPosts(locale);
   const recentPosts = allPosts
     .filter((p) => p.slug !== slug)
     .slice(0, 5);
 
-  const toolOfTheWeek = getToolOfTheWeek(locale);
+  const toolOfTheWeek = await getToolOfTheWeek(locale);
+  const allTools = await getAllTools(locale);
 
   const dateLocale = locale === 'ja' ? 'ja-JP' : 'en-US';
 
@@ -127,7 +128,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       if (!tools) return null;
       const slugs = (tools as string).split(',').map(s => s.trim());
       const toolsData = slugs
-        .map(slug => getToolBySlug(slug, locale)?.metadata)
+        .map(slug => allTools.find((t) => t.slug === slug))
         .filter((t): t is ToolMetadata => t !== undefined);
 
       if (toolsData.length === 0) return null;

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -18,7 +18,7 @@ export default async function BlogPage({
   const { locale } = await params;
   const t = await getTranslations("BlogPage");
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
-  const posts = getAllPosts(locale);
+  const posts = await getAllPosts(locale);
 
   const breadcrumbItems: BreadcrumbItem[] = [
     { label: tBreadcrumbs('home'), href: '/' },

--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -74,7 +74,7 @@ export default async function CategoryPage({
   const targetCategories = CATEGORY_MAPPINGS[slug as keyof typeof CATEGORY_MAPPINGS];
   
   // Fetch all tools and filter
-  const tools = getAllTools(locale);
+  const tools = await getAllTools(locale);
   const filteredTools = tools.filter((tool) => 
     targetCategories.includes(tool.category)
   );

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -27,7 +27,7 @@ export default async function ComparePage({
   params: Promise<{ locale: string }>
 }) {
   const { locale } = await params;
-  const tools = getAllTools(locale);
+  const tools = await getAllTools(locale);
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
 
   const breadcrumbItems: BreadcrumbItem[] = [

--- a/src/app/[locale]/deals/page.tsx
+++ b/src/app/[locale]/deals/page.tsx
@@ -29,7 +29,7 @@ export default async function DealsPage({
   const { locale } = await params;
   const t = await getTranslations('DealsPage');
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
-  const tools = getAllTools(locale);
+  const tools = await getAllTools(locale);
   const deals = tools.filter(tool => tool.discount);
 
   const breadcrumbItems: BreadcrumbItem[] = [

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -40,8 +40,8 @@ export default async function Home({
   const hasSearch = !!search;
 
   const t = await getTranslations('HomePage');
-  const tools = getAllTools(locale);
-  const toolOfTheWeek = getToolOfTheWeek(locale);
+  const tools = await getAllTools(locale);
+  const toolOfTheWeek = await getToolOfTheWeek(locale);
   const editorsChoiceSlugs = ['speechify', 'mixo', 'copy-ai', 'basedlabs', 'homesage'];
   const editorsChoiceTools = tools.filter(tool => editorsChoiceSlugs.includes(tool.slug));
 

--- a/src/app/[locale]/tools/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/tools/[slug]/opengraph-image.tsx
@@ -13,7 +13,7 @@ export const contentType = 'image/png';
 
 export default async function Image({ params }: { params: Promise<{ slug: string; locale: string }> }) {
   const { slug, locale } = await params;
-  const tool = getToolBySlug(slug, locale);
+  const tool = await getToolBySlug(slug, locale);
 
   if (!tool) {
     return new ImageResponse(

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata(
   { params }: { params: Promise<{ slug: string; locale: string }> }
 ): Promise<Metadata> {
   const { slug, locale } = await params;
-  const tool = getToolBySlug(slug, locale);
+  const tool = await getToolBySlug(slug, locale);
 
   if (!tool) {
     return {
@@ -59,7 +59,7 @@ export async function generateMetadata(
 
 export default async function ToolPage({ params }: { params: Promise<{ slug: string; locale: string }> }) {
   const { slug, locale } = await params;
-  const tool = getToolBySlug(slug, locale);
+  const tool = await getToolBySlug(slug, locale);
   const t = await getTranslations('ToolPage');
   const tBreadcrumbs = await getTranslations('Breadcrumbs');
   const tShare = await getTranslations('ShareButtons');
@@ -70,8 +70,8 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
 
   const { metadata, content } = tool;
   const { verified, last_updated } = metadata;
-  const relatedTools = getRelatedTools(metadata, 3, locale);
-  const relatedPosts = getRelatedPosts(metadata, 3, locale);
+  const relatedTools = await getRelatedTools(metadata, 3, locale);
+  const relatedPosts = await getRelatedPosts(metadata, 3, locale);
   const jsonLd = generateToolSchema(tool);
   const url = `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}/tools/${slug}`;
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -39,7 +39,7 @@ function getStaticPages(dir: string, basePath: string = ''): string[] {
   return pages
 }
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://ai-tool-navigator.vercel.app').replace(/\/$/, '')
   const locales = routing.locales
 
@@ -61,15 +61,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
   )
 
   // 2. Tools
-  const toolEntries = locales.flatMap((locale) => {
-    const tools = getAllTools(locale)
+  const toolEntries = (await Promise.all(locales.map(async (locale) => {
+    const tools = await getAllTools(locale)
     return tools.map((tool) => ({
       url: `${baseUrl}/${locale}/tools/${tool.slug}`,
       lastModified: tool.last_updated ? new Date(tool.last_updated) : new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.9,
     }))
-  })
+  }))).flat()
 
   // 3. Categories
   const categoryEntries = locales.flatMap((locale) =>
@@ -82,15 +82,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
   )
 
   // 4. Blog Posts
-  const postEntries = locales.flatMap((locale) => {
-    const posts = getAllPosts(locale)
+  const postEntries = (await Promise.all(locales.map(async (locale) => {
+    const posts = await getAllPosts(locale)
     return posts.map((post) => ({
       url: `${baseUrl}/${locale}/blog/${post.slug}`,
       lastModified: new Date(post.date),
       changeFrequency: 'monthly' as const,
       priority: 0.7,
     }))
-  })
+  }))).flat()
 
   return [
     ...staticEntries,

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import { unstable_cache } from 'next/cache';
 import { ToolMetadata } from './tools';
 
 const postsDirectory = path.join(process.cwd(), 'content/posts');
@@ -41,7 +42,7 @@ export interface Post {
   content: string;
 }
 
-export function getAllPosts(locale: string = 'en'): PostMetadata[] {
+const _getAllPosts = async (locale: string = 'en'): Promise<PostMetadata[]> => {
   // Try to find posts for the requested locale
   const localeDirectory = path.join(postsDirectory, locale);
   
@@ -81,9 +82,15 @@ export function getAllPosts(locale: string = 'en'): PostMetadata[] {
       return -1;
     }
   });
-}
+};
 
-export function getPostBySlug(slug: string, locale: string = 'en'): Post | null {
+export const getAllPosts = unstable_cache(
+  _getAllPosts,
+  ['posts-all'],
+  { tags: ['posts'] }
+);
+
+const _getPostBySlug = async (slug: string, locale: string = 'en'): Promise<Post | null> => {
   let fullPath = path.join(postsDirectory, locale, `${slug}.md`);
 
   // Fallback to root or 'en'
@@ -106,7 +113,13 @@ export function getPostBySlug(slug: string, locale: string = 'en'): Post | null 
     } as PostMetadata,
     content: matterResult.content,
   };
-}
+};
+
+export const getPostBySlug = unstable_cache(
+  _getPostBySlug,
+  ['post-slug'],
+  { tags: ['posts'] }
+);
 
 export function getPostSlugs() {
   if (!fs.existsSync(postsDirectory)) {
@@ -122,8 +135,8 @@ export function getPostSlugs() {
     });
 }
 
-export function getRelatedPosts(tool: ToolMetadata, limit: number = 3, locale: string = 'en'): PostMetadata[] {
-  const allPosts = getAllPosts(locale);
+export async function getRelatedPosts(tool: ToolMetadata, limit: number = 3, locale: string = 'en'): Promise<PostMetadata[]> {
+  const allPosts = await getAllPosts(locale);
 
   if (allPosts.length === 0) {
     return [];

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import { unstable_cache } from 'next/cache';
 
 const toolsDirectory = path.join(process.cwd(), 'content/tools');
 
@@ -31,7 +32,7 @@ export interface Tool {
   content: string;
 }
 
-export function getAllTools(locale: string = 'en'): ToolMetadata[] {
+const _getAllTools = async (locale: string = 'en'): Promise<ToolMetadata[]> => {
   const enDirectory = path.join(toolsDirectory, 'en');
   // Ensure directory exists
   if (!fs.existsSync(enDirectory)) {
@@ -64,9 +65,15 @@ export function getAllTools(locale: string = 'en'): ToolMetadata[] {
   });
 
   return allToolsData;
-}
+};
 
-export function getToolBySlug(slug: string, locale: string = 'en'): Tool | null {
+export const getAllTools = unstable_cache(
+  _getAllTools,
+  ['tools-all'],
+  { tags: ['tools'] }
+);
+
+const _getToolBySlug = async (slug: string, locale: string = 'en'): Promise<Tool | null> => {
   let fullPath = path.join(toolsDirectory, locale, `${slug}.md`);
 
   // Fallback to English
@@ -88,10 +95,16 @@ export function getToolBySlug(slug: string, locale: string = 'en'): Tool | null 
     } as ToolMetadata,
     content: matterResult.content,
   };
-}
+};
 
-export function getToolOfTheWeek(locale: string = 'en'): ToolMetadata | null {
-  const tools = getAllTools(locale);
+export const getToolBySlug = unstable_cache(
+  _getToolBySlug,
+  ['tool-slug'],
+  { tags: ['tools'] }
+);
+
+export async function getToolOfTheWeek(locale: string = 'en'): Promise<ToolMetadata | null> {
+  const tools = await getAllTools(locale);
   return tools.find((tool) => tool.tool_of_the_week) || null;
 }
 
@@ -117,8 +130,8 @@ export function getToolSlugs() {
   return allParams;
 }
 
-export function getRelatedTools(currentTool: ToolMetadata, limit: number = 3, locale: string = 'en'): ToolMetadata[] {
-  const allTools = getAllTools(locale);
+export async function getRelatedTools(currentTool: ToolMetadata, limit: number = 3, locale: string = 'en'): Promise<ToolMetadata[]> {
+  const allTools = await getAllTools(locale);
   const candidates = allTools.filter(
     (tool) => tool.category === currentTool.category && tool.slug !== currentTool.slug
   );


### PR DESCRIPTION
Implemented a robust server-side caching strategy using Next.js `unstable_cache`. This refactor changes synchronous file-system reads for Tools and Posts into asynchronous, cached operations. This significantly improves performance by avoiding repeated file I/O and markdown parsing on every request.

Key changes:
- Wrapped `getAllTools`, `getToolBySlug`, `getAllPosts`, `getPostBySlug` with `unstable_cache`.
- Updated all page components (`page.tsx`), `layout.tsx` (if applicable), `sitemap.ts`, and `opengraph-image.tsx` to use `await` with these now-async functions.
- Fixed type errors related to Promise vs Array.
- Verified build and runtime functionality.

---
*PR created automatically by Jules for task [2374613483319973629](https://jules.google.com/task/2374613483319973629) started by @yuga-hashimoto*