### PR TITLE
Resolve merge conflicts for PR #242 (Copy Link button)

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,13 @@
+
+> ai-tool-navigator@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 2.1s
+○ Compiling /[locale]/blog/[slug] ...
+ GET /en/blog/best-ai-coding-tools-2026 200 in 7.3s (compile: 5.8s, proxy.ts: 138ms, generate-params: 829ms, render: 1411ms)

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { ComparisonTable } from "@/components/ComparisonTable";
 import { generateBlogPostSchema, generateBreadcrumbSchema } from "@/lib/schema";
 import { getToolOfTheWeek, getToolBySlug, ToolMetadata } from "@/lib/tools";
 import { ToolOfTheWeekSidebar } from "@/components/ToolOfTheWeekSidebar";
+import { HeaderLinkButton } from "@/components/HeaderLinkButton";
 import { GoogleAdsensePlaceholder } from "@/components/GoogleAdsensePlaceholder";
 
 export async function generateStaticParams() {
@@ -107,13 +108,33 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
   const components = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-    h1: ({node: _node, ...props}: any) => <h1 className="scroll-mt-24" {...props} />,
+    h1: ({node: _node, children, id, ...props}: any) => (
+      <h1 id={id} className="scroll-mt-24 group relative flex items-center" {...props}>
+        <span>{children}</span>
+        {id && <HeaderLinkButton id={id} />}
+      </h1>
+    ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-    h2: ({node: _node, ...props}: any) => <h2 className="scroll-mt-24" {...props} />,
+    h2: ({node: _node, children, id, ...props}: any) => (
+      <h2 id={id} className="scroll-mt-24 group relative flex items-center" {...props}>
+        <span>{children}</span>
+        {id && <HeaderLinkButton id={id} />}
+      </h2>
+    ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-    h3: ({node: _node, ...props}: any) => <h3 className="scroll-mt-24" {...props} />,
+    h3: ({node: _node, children, id, ...props}: any) => (
+      <h3 id={id} className="scroll-mt-24 group relative flex items-center" {...props}>
+        <span>{children}</span>
+        {id && <HeaderLinkButton id={id} />}
+      </h3>
+    ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-    h4: ({node: _node, ...props}: any) => <h4 className="scroll-mt-24" {...props} />,
+    h4: ({node: _node, children, id, ...props}: any) => (
+      <h4 id={id} className="scroll-mt-24 group relative flex items-center" {...props}>
+        <span>{children}</span>
+        {id && <HeaderLinkButton id={id} />}
+      </h4>
+    ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     'related-post': (props: any) => {
       const { slug } = props;

--- a/src/components/HeaderLinkButton.tsx
+++ b/src/components/HeaderLinkButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Link as LinkIcon, Check } from "lucide-react";
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+
+export function HeaderLinkButton({ id, className }: { id: string, className?: string }) {
+  const [copied, setCopied] = useState(false);
+  const t = useTranslations("ToolPage");
+
+  const handleCopy = async () => {
+    try {
+      const url = `${window.location.origin}${window.location.pathname}#${id}`;
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy: ", err);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center p-1 rounded-md transition-all ml-2 opacity-0 group-hover:opacity-100 focus:opacity-100",
+        copied ? "text-green-600 bg-green-50 dark:bg-green-900/20 dark:text-green-400" : "text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800",
+        className
+      )}
+      aria-label={t("copyLink")}
+      title={t("copyLink")}
+    >
+      {copied ? (
+        <Check className="h-4 w-4" />
+      ) : (
+        <LinkIcon className="h-4 w-4" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
Resolved merge conflicts for PR #242. The feature adds a 'Copy Link' button to blog post headers (h1-h4) that appears on hover.

Changes:
1.  **Component Integration:** `HeaderLinkButton` is integrated into `src/app/[locale]/blog/[slug]/page.tsx` within the MDX `components` map.
2.  **Conflict Resolution:**
    *   Combined imports in `BlogPostPage`.
    *   Preserved `GoogleAdsensePlaceholder` and `generateBreadcrumbSchema` from main.
    *   Merged translation keys in `messages/*.json`.
    *   Discarded changes in other files where `pr-242` had outdated copies of the repo structure.

Verification:
- Build passed.
- Frontend verification (Playwright) confirmed the button appears on hover and has the correct aria-label.


---
*PR created automatically by Jules for task [17526735326758457370](https://jules.google.com/task/17526735326758457370) started by @yuga-hashimoto*