### PR TITLE
Implement server-side caching strategy

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -87,7 +87,7 @@ const _getAllPosts = async (locale: string = 'en'): Promise<PostMetadata[]> => {
 export const getAllPosts = unstable_cache(
   _getAllPosts,
   ['posts-all'],
-  { tags: ['posts'] }
+  { tags: ['posts'], revalidate: 3600 }
 );
 
 const _getPostBySlug = async (slug: string, locale: string = 'en'): Promise<Post | null> => {
@@ -118,7 +118,7 @@ const _getPostBySlug = async (slug: string, locale: string = 'en'): Promise<Post
 export const getPostBySlug = unstable_cache(
   _getPostBySlug,
   ['post-slug'],
-  { tags: ['posts'] }
+  { tags: ['posts'], revalidate: 3600 }
 );
 
 export function getPostSlugs() {
@@ -135,7 +135,7 @@ export function getPostSlugs() {
     });
 }
 
-export async function getRelatedPosts(tool: ToolMetadata, limit: number = 3, locale: string = 'en'): Promise<PostMetadata[]> {
+const _getRelatedPosts = async (tool: ToolMetadata, limit: number = 3, locale: string = 'en'): Promise<PostMetadata[]> => {
   const allPosts = await getAllPosts(locale);
 
   if (allPosts.length === 0) {
@@ -189,3 +189,9 @@ export async function getRelatedPosts(tool: ToolMetadata, limit: number = 3, loc
 
   return related.slice(0, limit);
 }
+
+export const getRelatedPosts = unstable_cache(
+  _getRelatedPosts,
+  ['related-posts'],
+  { tags: ['posts'], revalidate: 3600 }
+);

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -70,7 +70,7 @@ const _getAllTools = async (locale: string = 'en'): Promise<ToolMetadata[]> => {
 export const getAllTools = unstable_cache(
   _getAllTools,
   ['tools-all'],
-  { tags: ['tools'] }
+  { tags: ['tools'], revalidate: 3600 }
 );
 
 const _getToolBySlug = async (slug: string, locale: string = 'en'): Promise<Tool | null> => {
@@ -100,13 +100,19 @@ const _getToolBySlug = async (slug: string, locale: string = 'en'): Promise<Tool
 export const getToolBySlug = unstable_cache(
   _getToolBySlug,
   ['tool-slug'],
-  { tags: ['tools'] }
+  { tags: ['tools'], revalidate: 3600 }
 );
 
-export async function getToolOfTheWeek(locale: string = 'en'): Promise<ToolMetadata | null> {
+const _getToolOfTheWeek = async (locale: string = 'en'): Promise<ToolMetadata | null> => {
   const tools = await getAllTools(locale);
   return tools.find((tool) => tool.tool_of_the_week) || null;
 }
+
+export const getToolOfTheWeek = unstable_cache(
+  _getToolOfTheWeek,
+  ['tool-of-the-week'],
+  { tags: ['tools'], revalidate: 3600 }
+);
 
 export function getToolSlugs() {
   const locales = ['en', 'ja'];
@@ -130,7 +136,7 @@ export function getToolSlugs() {
   return allParams;
 }
 
-export async function getRelatedTools(currentTool: ToolMetadata, limit: number = 3, locale: string = 'en'): Promise<ToolMetadata[]> {
+const _getRelatedTools = async (currentTool: ToolMetadata, limit: number = 3, locale: string = 'en'): Promise<ToolMetadata[]> => {
   const allTools = await getAllTools(locale);
   const candidates = allTools.filter(
     (tool) => tool.category === currentTool.category && tool.slug !== currentTool.slug
@@ -144,3 +150,9 @@ export async function getRelatedTools(currentTool: ToolMetadata, limit: number =
 
   return candidates.slice(0, limit);
 }
+
+export const getRelatedTools = unstable_cache(
+  _getRelatedTools,
+  ['related-tools'],
+  { tags: ['tools'], revalidate: 3600 }
+);


### PR DESCRIPTION
Implemented a robust server-side caching strategy using Next.js `unstable_cache`.

Key changes:
- `src/lib/tools.ts`: Wrapped `getRelatedTools` and `getToolOfTheWeek` with caching. Added 1-hour revalidation to `getAllTools`, `getToolBySlug`, and the new cached functions.
- `src/lib/posts.ts`: Wrapped `getRelatedPosts` with caching. Added 1-hour revalidation to `getAllPosts`, `getPostBySlug`, and `getRelatedPosts`.

This ensures that expensive operations like shuffling related tools or parsing markdown are cached, improving response times while keeping content fresh with ISR.

---
*PR created automatically by Jules for task [327791298490507629](https://jules.google.com/task/327791298490507629) started by @yuga-hashimoto*