### PR TITLE
💰 Revenue Optimizer: Improve SEO metadata on /tools page

### DIFF
--- a/src/app/[locale]/tools/page.tsx
+++ b/src/app/[locale]/tools/page.tsx
@@ -9,9 +9,10 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>
 }): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'ToolsPage' });
   return {
-    title: "Browse AI Tools",
-    description: "Browse and discover the best AI tools for your workflow. Filter by category, rating, price, and more.",
+    title: `${t('title')} | AI Tool Navigator`,
+    description: t('description'),
     alternates: {
       canonical: `/${locale}/tools`,
     },


### PR DESCRIPTION
Replaced hardcoded English SEO title and description on the `/tools` page with translated strings using `getTranslations('ToolsPage')`. Added the ' | AI Tool Navigator' suffix to the title. This improves international SEO and search intent matching for the tools hub page.

---
*PR created automatically by Jules for task [12327728032694371854](https://jules.google.com/task/12327728032694371854) started by @yuga-hashimoto*