### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback for exit-intent leads

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -331,9 +331,14 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        console.log(`[EXIT INTENT LEAD] New lead appended to Google Sheets: ${leadId} at ${new Date().toISOString()}`);
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead captured locally: ${leadId}`);
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      console.warn('Google Sheets append failed, falling back to local logging:', sheetsError);
+      console.log(`[EXIT INTENT LEAD FALLBACK] New lead captured locally: ${leadId}`);
     }
 
     // Log the submission


### PR DESCRIPTION
As the "Ops Guard" agent, I've improved the operational reliability and visibility of form submissions on the `/api/leads/exit-intent` endpoint.

**Context:**
The exit-intent lead capture API attempts to save new leads to a Google Sheet via a service account. Previously, if the configuration was missing or failed, it logged a generic error message, lacking a clear fallback identifier for log scraping. This was inconsistent with how other endpoints (like `/api/subscribe`) handled the same situation.

**Changes:**
- Updated `src/app/api/leads/exit-intent/route.ts` to log a successful Google Sheets append operation.
- Added explicit `[EXIT INTENT LEAD FALLBACK]` structured logging when `GOOGLE_SERVICE_ACCOUNT_JSON` is missing or the append fails.
- Switched `console.error` to `console.warn` for expected fallback paths, reducing false-positive alerts while ensuring leads are still logged locally and can be recovered later.

---
*PR created automatically by Jules for task [3809883231977416877](https://jules.google.com/task/3809883231977416877) started by @yuga-hashimoto*