### PR TITLE
💰 Revenue Optimizer: Improve CTA clarity

### DIFF
--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -6,6 +6,7 @@ import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { getAllTools, ToolMetadata } from "@/lib/tools";
+import { ExternalLink } from "lucide-react";
 import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
 import { getComparePresetBySlug, parseComparisonSlug } from "@/lib/compare-pages";
 import { getEditorialToolStatus, isReviewPendingToolSlug } from "@/lib/editorial";
@@ -286,6 +287,7 @@ export default async function CompareTemplatePage({
                             className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-2 h-4 w-4" />
                           </AffiliateLinkButton>
                         </div>
                       </td>


### PR DESCRIPTION
This PR adds the `ExternalLink` icon (from `lucide-react`) to the "Visit site" `AffiliateLinkButton` on the compare template pages (`src/app/[locale]/compare/[comparisonSlug]/page.tsx`).

This is a monetization/revenue optimization change designed to:
- Improve CTA clarity and trust by clearly signaling an external transition.
- Standardize the `AffiliateLinkButton` usage on this layout to match other outbound links across the site.
- Comply with the `<120 lines` constraint and strictly avoid spammy tactics.

Verified locally with a headless Playwright screenshot confirming the visual improvement on the 'ChatGPT vs Claude vs Perplexity' preset page.

---
*PR created automatically by Jules for task [18253932994727094330](https://jules.google.com/task/18253932994727094330) started by @yuga-hashimoto*