### PR TITLE
💰 Revenue Optimizer: Improve affiliate disclosure visibility on category pages

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -275,6 +276,7 @@ export default async function CategoryPage({
             forceShow={true}
             className="mb-10"
           />
+          <AffiliateDisclaimer variant="compact" className="mb-8" />
           <div className="max-w-3xl">
             <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
               {copy.compareTableTitle}


### PR DESCRIPTION
Added the `AffiliateDisclaimer` component to `src/app/[locale]/category/[slug]/page.tsx` just above the comparison table to improve affiliate disclosure visibility where appropriate. This is a small, safe improvement to monetization transparency that complies with editorially clean standards and does not involve spammy SEO tactics.

---
*PR created automatically by Jules for task [273114164219128229](https://jules.google.com/task/273114164219128229) started by @yuga-hashimoto*