### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -10,6 +10,7 @@ import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
 import { getComparePresetBySlug, parseComparisonSlug } from "@/lib/compare-pages";
 import { getEditorialToolStatus, isReviewPendingToolSlug } from "@/lib/editorial";
 import { Link } from "@/i18n/routing";
+import { ExternalLink } from "lucide-react";
 
 interface PageParams {
   locale: string;
@@ -286,6 +287,7 @@ export default async function CompareTemplatePage({
                             className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-2 h-4 w-4" />
                           </AffiliateLinkButton>
                         </div>
                       </td>


### PR DESCRIPTION
I improved the clarity of the CTA in the comparison template (`src/app/[locale]/compare/[comparisonSlug]/page.tsx`).

By importing and adding the `ExternalLink` icon from `lucide-react` to the `<AffiliateLinkButton>`, it visibly signals to users that the "Visit site" action will take them to an external, third-party site. This provides a more trustworthy and clear user experience for outbound affiliate or sponsor links.

Testing:
- Checked build via `npm run build` with increased old space size
- Checked standard e2e routing via `npx playwright test` 
- Captured a local Playwright screenshot of a preset compare page (`/en/compare/chatgpt-vs-claude-vs-perplexity`) to verify that the external link icon successfully appears next to the Visit buttons.

---
*PR created automatically by Jules for task [12157421257086721306](https://jules.google.com/task/12157421257086721306) started by @yuga-hashimoto*