### PR TITLE
🛠️ Ops Guard: Fix exit intent fallback logging

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -331,9 +331,19 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        console.log(`[EXIT INTENT LEAD] New lead appended to Google Sheets: lead_${leadId.substring(5)} at ${new Date().toISOString()}`);
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead: lead_${leadId.substring(5)} at ${new Date().toISOString()}`);
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      const errorMsg = sheetsError instanceof Error ? sheetsError.message : String(sheetsError);
+      if (errorMsg.includes('not configured')) {
+        console.warn(`[EXIT INTENT LEAD FALLBACK] Google Sheets not configured. Lead recorded locally: lead_${leadId.substring(5)}`);
+      } else {
+        console.warn('Google Sheets append failed, falling back to local DB record only:', sheetsError);
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead recorded locally: lead_${leadId.substring(5)}`);
+      }
     }
 
     // Log the submission


### PR DESCRIPTION
This PR enhances operational observability and conversion logging in the `exit-intent` lead capture API endpoint (`src/app/api/leads/exit-intent/route.ts`). 

Previously, if the Google Sheets integration failed, it simply logged a generic `console.error`. Now, it correctly captures the error, checks if the failure was due to a missing configuration, and logs a clear, structured `console.warn` message (using the standard `[EXIT INTENT LEAD FALLBACK]` identifier). It also explicitly handles and logs the state where `GOOGLE_SERVICE_ACCOUNT_JSON` is not set at all. This brings the endpoint's logging behavior inline with other lead/conversion capture routes in the repository, making it easier for ops and monitoring tools to track successful local database fallbacks vs total data loss.

---
*PR created automatically by Jules for task [7333689155114984246](https://jules.google.com/task/7333689155114984246) started by @yuga-hashimoto*