### PR TITLE
🛠️ Ops Guard: Fix exit intent google sheets fallback

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -331,9 +331,19 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        console.log(`[EXIT INTENT LEAD] New lead appended to Google Sheets: ${leadId}`);
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead: ${leadId}`);
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      const errorMsg = sheetsError instanceof Error ? sheetsError.message : String(sheetsError);
+      if (errorMsg.includes('not configured')) {
+        console.warn(`[EXIT INTENT LEAD FALLBACK] Google Sheets not configured. Lead recorded locally: ${leadId}`);
+      } else {
+        console.warn('Google Sheets append failed, falling back to local logging:', sheetsError);
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead: ${leadId}`);
+      }
     }
 
     // Log the submission


### PR DESCRIPTION
Improves operational visibility and debugging for the `exit-intent` lead API. It now explicitly distinguishes between a missing Google Service Account configuration and an actual connection error, providing clearer fallback logging with the `[EXIT INTENT LEAD FALLBACK]` prefix. This aligns its behavior with other form submission APIs in the repository like `/api/subscribe` and `/api/submit`.

---
*PR created automatically by Jules for task [12927880919893193933](https://jules.google.com/task/12927880919893193933) started by @yuga-hashimoto*