### PR TITLE
🛡️ Trust Builder: Improve schema.org accuracy for tools

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -114,6 +117,22 @@ export function generateProductSchema(tool: Tool) {
       "reviewCount": metadata.rating_breakdown ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0) : 1,
       "bestRating": bestRating,
       "worstRating": "1"
+    };
+
+    schema.review = {
+      "@type": "Review",
+      "reviewRating": {
+        "@type": "Rating",
+        "ratingValue": metadata.rating,
+        "bestRating": bestRating,
+        "worstRating": "1"
+      },
+      "author": {
+        "@type": "Organization",
+        "name": "AI Tool Navigator"
+      },
+      "reviewBody": metadata.description,
+      "datePublished": metadata.last_updated || new Date().toISOString()
     };
   }
 
@@ -155,11 +174,11 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.pricing === 'free') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",
-      "url": metadata.affiliate_link,
+      "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "price": "0",
       "priceCurrency": "USD",
       "availability": "https://schema.org/InStock"


### PR DESCRIPTION
🛡️ Trust Builder: Improve schema.org accuracy for tools

This PR makes a small improvement to increase transparency and structured discoverability by addressing a schema accuracy issue. 

Previously, `generateProductSchema` and `generateToolSchema` would hardcode a price of `$0` for all tools (or any tool with an affiliate link), which could be misleading for paid tools. This PR ensures that a `$0` offer is only emitted in the schema if `metadata.pricing === 'free'`. 

Additionally, it adds a `Review` object to `generateProductSchema` attributing the editorial rating to 'AI Tool Navigator', matching the pattern in `generateToolSchema` and improving structured discoverability.

---
*PR created automatically by Jules for task [12661596042064173205](https://jules.google.com/task/12661596042064173205) started by @yuga-hashimoto*