### PR TITLE
💰 Revenue Optimizer: Improve CTA clarity on comparison tables

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { ExternalLink } from "lucide-react";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -347,9 +348,10 @@ export default async function CategoryPage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position="category_compare_table"
-                            className="text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
+                            className="inline-flex items-center text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
                           >
                             {copy.visitLabel}
+                            <ExternalLink className="ml-1 h-3 w-3 inline" />
                           </AffiliateLinkButton>
                         </div>
                       </td>

--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
+import { ExternalLink } from "lucide-react";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { getAllTools, ToolMetadata } from "@/lib/tools";
 import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
@@ -286,6 +287,7 @@ export default async function CompareTemplatePage({
                             className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-1.5 h-4 w-4" />
                           </AffiliateLinkButton>
                         </div>
                       </td>


### PR DESCRIPTION
This PR acts as the Revenue Optimizer to improve CTA clarity on the site.

It adds an `ExternalLink` icon from `lucide-react` to the outbound CTA buttons (e.g., "Visit site") within the main tool comparison tables on:
- Preset Comparison Pages (`src/app/[locale]/compare/[comparisonSlug]/page.tsx`)
- Category Landing Pages (`src/app/[locale]/category/[slug]/page.tsx`)

This provides a clear visual signal to users that the link leads to an external, third-party site, which builds trust and improves click clarity for affiliate performance without using deceptive or spammy tactics.

Verified locally using Playwright visual testing and E2E test suites.

---
*PR created automatically by Jules for task [2451787130511903166](https://jules.google.com/task/2451787130511903166) started by @yuga-hashimoto*