### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback for exit intent leads

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -331,9 +331,18 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead recorded locally: lead_${leadId.substring(5)}`);
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      const errorMsg = sheetsError instanceof Error ? sheetsError.message : String(sheetsError);
+      if (errorMsg.includes('not configured')) {
+        console.warn(`[EXIT INTENT LEAD FALLBACK] Google Sheets not configured. Lead recorded locally: lead_${leadId.substring(5)}`);
+      } else {
+        console.warn('Google Sheets append failed, falling back to local storage only:', sheetsError);
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead recorded locally: lead_${leadId.substring(5)}`);
+      }
     }
 
     // Log the submission


### PR DESCRIPTION
This PR addresses an operations logging issue where exit intent leads were silently failing to log their specific identity correctly during fallback scenarios, unlike other form submission routes.

Changes:
- Implemented `[EXIT INTENT LEAD FALLBACK]` logs using `console.log` and `console.warn`
- Handled both missing `GOOGLE_SERVICE_ACCOUNT_JSON` configuration and unexpected `try/catch` errors when hitting Google Sheets API.

---
*PR created automatically by Jules for task [8377377573350551904](https://jules.google.com/task/8377377573350551904) started by @yuga-hashimoto*