### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior in exit intent leads

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -331,9 +331,14 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        console.log(`[EXIT INTENT LEAD] New subscriber appended to Google Sheets: lead_${leadId.substring(5)} at ${new Date().toISOString()}`);
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        console.log(`[EXIT INTENT LEAD FALLBACK] New subscriber: lead_${leadId.substring(5)} at ${new Date().toISOString()}`);
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      console.warn('Google Sheets append failed, falling back to local logging:', sheetsError);
+      console.log(`[EXIT INTENT LEAD FALLBACK] New subscriber: lead_${leadId.substring(5)} at ${new Date().toISOString()}`);
     }
 
     // Log the submission


### PR DESCRIPTION
This PR addresses an operational issue where exit intent leads failing to append to Google Sheets due to missing configuration or API errors were not explicitly marked as `[EXIT INTENT LEAD FALLBACK]` in the logs.

This matches the robust fallback logging behavior already present in `api/submit` and `api/subscribe`.

---
*PR created automatically by Jules for task [1471408291688212139](https://jules.google.com/task/1471408291688212139) started by @yuga-hashimoto*