### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getCategoryLandingContent } from "@/lib/category-landing";
 import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
+import { ExternalLink } from "lucide-react";
 
 export async function generateStaticParams() {
   return Object.keys(CATEGORY_MAPPINGS).map((slug) => ({
@@ -347,9 +348,10 @@ export default async function CategoryPage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position="category_compare_table"
-                            className="text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
+                            className="inline-flex items-center text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
                           >
                             {copy.visitLabel}
+                            <ExternalLink className="ml-1 h-3 w-3" />
                           </AffiliateLinkButton>
                         </div>
                       </td>

--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -10,6 +10,7 @@ import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
 import { getComparePresetBySlug, parseComparisonSlug } from "@/lib/compare-pages";
 import { getEditorialToolStatus, isReviewPendingToolSlug } from "@/lib/editorial";
 import { Link } from "@/i18n/routing";
+import { ExternalLink } from "lucide-react";
 
 interface PageParams {
   locale: string;
@@ -286,6 +287,7 @@ export default async function CompareTemplatePage({
                             className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-2 h-4 w-4" />
                           </AffiliateLinkButton>
                         </div>
                       </td>

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
**Revenue Optimizer: Improve CTA Clarity**

Added the `ExternalLink` icon from `lucide-react` to the "Visit site" `AffiliateLinkButton` components on the Compare Preset page (`src/app/[locale]/compare/[comparisonSlug]/page.tsx`) and the Category Landing page (`src/app/[locale]/category/[slug]/page.tsx`).

This visual cue clarifies that the link is outbound, which manages user expectations, improves editorial trustworthiness, and aligns with affiliate link best practices to increase high-intent CTR. All changes are purely cosmetic and successfully passed E2E tests and visual verification.

---
*PR created automatically by Jules for task [14099053677583674515](https://jules.google.com/task/14099053677583674515) started by @yuga-hashimoto*