### PR TITLE
🧭 Trust Builder: Improve affiliate disclosure on category pages

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -264,6 +265,9 @@ export default async function CategoryPage({
 
           <div className="mt-8">
             <HeroSearchBar />
+          </div>
+          <div className="mt-8">
+            <AffiliateDisclaimer variant="compact" />
           </div>
         </section>
 


### PR DESCRIPTION
This PR improves trust and transparency by adding the standard `AffiliateDisclaimer` to category landing pages. This ensures users are aware of potential affiliate relationships when browsing curated tool lists, aligning with the "Trust Builder" goals of clear editorial policies and disclosures.

---
*PR created automatically by Jules for task [10213973831548778554](https://jules.google.com/task/10213973831548778554) started by @yuga-hashimoto*