### PR TITLE
💰 Revenue Optimizer: Improve category comparison CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { ArrowRight } from "lucide-react";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -233,9 +234,10 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="group inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link


### PR DESCRIPTION
I have updated the "Compare this category" Call-to-Action on the Category Hub landing pages (`src/app/[locale]/category/[slug]/page.tsx`). 

By adding an `ArrowRight` icon and a subtle hover animation (`group-hover:translate-x-1`), the button feels more actionable and clearly signals navigation to the comparison funnel. This small UI improvement aligns with the Revenue Optimizer persona's goal of improving CTA clarity to drive deeper engagement and higher conversion through the site's primary user journey. I verified the styling and ran the build and E2E tests to ensure everything functions properly.

---
*PR created automatically by Jules for task [14230881753262214356](https://jules.google.com/task/14230881753262214356) started by @yuga-hashimoto*