### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback for exit intent leads

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -331,9 +331,14 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        console.log(`[EXIT INTENT LEAD] New lead appended to Google Sheets: ${leadId} at ${new Date().toISOString()}`);
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead captured locally: ${leadId} at ${new Date().toISOString()}`);
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      console.warn('Google Sheets append failed, falling back to local logging:', sheetsError);
+      console.log(`[EXIT INTENT LEAD FALLBACK] New lead captured locally: ${leadId} at ${new Date().toISOString()}`);
     }
 
     // Log the submission


### PR DESCRIPTION
When the exit intent leads API was processing a new lead, it failed silently or without logging the lead context locally if `GOOGLE_SERVICE_ACCOUNT_JSON` was not configured or if the append to Google Sheets failed. This change adds a warning `console.warn` along with `[EXIT INTENT LEAD FALLBACK]` logs to reliably record leads locally, creating consistency with the other form handling APIs (like submissions, subscribe, and partner-inquiry).

---
*PR created automatically by Jules for task [3239461088340568239](https://jules.google.com/task/3239461088340568239) started by @yuga-hashimoto*