### PR TITLE
📝 Content Sync: Refresh alibaba-coding-plan

### DIFF
--- a/content/tools/en/alibaba-coding-plan.md
+++ b/content/tools/en/alibaba-coding-plan.md
@@ -6,18 +6,18 @@ description: "Alibaba Cloud's fixed-price Coding Plan for Qwen Code, Claude Code
 rating: 4.7
 pros:
   - "Strong first-party path for Qwen Code across CLI and editor workflows"
-  - "Fixed monthly pricing is easier to budget than open-ended API spend"
+  - "$50/month fixed pricing is easier to budget than open-ended API spend"
   - "Supports multiple coding models, not just Qwen"
 cons:
   - "Coding Plan keys and base URLs differ from standard Model Studio API access"
   - "Primarily designed for interactive coding tools rather than generic automation"
 affiliate_link: "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
 pricing: "paid"
-price: "Starter $10 / Pro $50"
+price: "$50 /month"
 platform:
   - "Web"
   - "Desktop"
-last_updated: "2026-03-07"
+last_updated: "2026-03-29"
 verified: true
 ---
 
@@ -33,7 +33,7 @@ Alibaba provides an official setup path for Qwen Code, including dedicated CLI a
 
 ### 2. Predictable pricing
 
-The public plan overview lists Starter and Pro tiers, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
+The public plan overview highlights a $50/month Pro tier, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage. (Note: The Lite plan was discontinued for new subscriptions on March 20, 2026).
 
 ### 3. Multi-model support
 

--- a/content/tools/ja/alibaba-coding-plan.md
+++ b/content/tools/ja/alibaba-coding-plan.md
@@ -6,18 +6,18 @@ description: 'Alibaba Cloud の定額型 Coding Plan。Qwen Code、Claude Code�
 rating: 4.7
 pros:
   - 'Qwen Code の公式導線が強く CLI と拡張機能の両方が揃う'
-  - 'Starter / Pro の月額制で予算管理しやすい'
+  - '$50/月の固定費で予算管理しやすい'
   - 'Qwen 系だけでなく複数モデルを使い分けやすい'
 cons:
   - '通常の Model Studio API とはキーと Base URL が別'
   - '汎用 API 自動化より対話型コーディングツール向け'
 affiliate_link: 'https://www.alibabacloud.com/help/ja/model-studio/coding-plan'
 pricing: 'paid'
-price: 'Starter $10 / Pro $50'
+price: '$50 /月'
 platform:
   - 'Web'
   - 'Desktop'
-last_updated: '2026-03-07'
+last_updated: '2026-03-29'
 verified: true
 ---
 
@@ -33,7 +33,7 @@ Alibaba 側が Qwen Code の公式ガイドを用意しており、CLI やエデ
 
 ### 2. 月額制で回しやすい
 
-Starter / Pro のようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
+月額$50のProプラン（※Liteプランの新規受付は2026年3月に終了）なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
 
 ### 3. 複数モデルを選べる
 


### PR DESCRIPTION
This PR updates the Alibaba Cloud Model Studio Coding Plan content based on the latest `content-sync-state.json`.

**Changes made:**
- Changed pricing from "Starter $10 / Pro $50" to a single "$50 /month" tier.
- Updated `last_updated` date to reflect the sync run on Mar 29, 2026.
- Edited the pros list and the predictable pricing body section to note the fixed $50/month price and the discontinuation of the Lite plan.
- Applied these updates to both the English (`content/tools/en/alibaba-coding-plan.md`) and Japanese (`content/tools/ja/alibaba-coding-plan.md`) files.

---
*PR created automatically by Jules for task [3770787941214953579](https://jules.google.com/task/3770787941214953579) started by @yuga-hashimoto*