### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -328,16 +328,28 @@ export async function POST(request: NextRequest) {
     leadsStorage.set(leadId, leadRecord);
 
     // Add to Google Sheets if configured
+    let logPrefix = '[EXIT INTENT LEAD] New lead captured';
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        logPrefix = '[EXIT INTENT LEAD] New lead appended to Google Sheets';
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        logPrefix = '[EXIT INTENT LEAD FALLBACK] New lead captured locally';
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      const errorMsg = sheetsError instanceof Error ? sheetsError.message : String(sheetsError);
+      if (errorMsg.includes('not configured') || errorMsg.includes('not set')) {
+        console.warn(`[EXIT INTENT LEAD FALLBACK] Google Sheets not configured. Lead captured locally: ${leadId}`);
+        logPrefix = '[EXIT INTENT LEAD FALLBACK] New lead captured locally';
+      } else {
+        console.warn('Google Sheets append failed, falling back to local DB record only:', sheetsError);
+        logPrefix = '[EXIT INTENT LEAD FALLBACK] New lead captured locally';
+      }
     }
 
     // Log the submission
-    console.log(`[EXIT INTENT LEAD] New lead captured:
+    console.log(`${logPrefix}:
       Lead ID: ${leadId}
       Variant: ${variant}
       Source: ${source}


### PR DESCRIPTION
This PR improves the operational observability of the `/api/leads/exit-intent` route.

Previously, if Google Sheets was unconfigured or the append failed, the system would silently fall back to local database logging without a clear, identifiable fallback log prefix, unlike other endpoints such as `/api/submit` or `/api/subscribe`.

Changes:
- Replaced static log prefixes with dynamic prefixes that reflect the lead capture state (Appended vs. Fallback).
- Added checks for `not configured` or `not set` errors to gracefully demote the log level to a warning and explicitly state `[EXIT INTENT LEAD FALLBACK]`.
- Ensured the detailed lead block is logged consistently across success and fallback paths.

---
*PR created automatically by Jules for task [5778209624277437221](https://jules.google.com/task/5778209624277437221) started by @yuga-hashimoto*