### PR TITLE
🛠️ Ops Guard: Fix exit intent Google Sheets fallback behavior

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { securityCheck, createRateLimitHeaders } from '@/lib/security';
-import { getClientIP } from '@/lib/security/bot-detection';
-import { trackRequest } from '@/lib/security/anomaly-detection';
-import { logFormSubmission } from '@/lib/security/audit-log';
-import { appendSubscriber } from '@/lib/google-sheets';
-import { hashEmail, generateLeadId } from '@/lib/security/email-hashing';
-import crypto from 'crypto';
+import { NextRequest, NextResponse } from "next/server";
+import { securityCheck, createRateLimitHeaders } from "@/lib/security";
+import { getClientIP } from "@/lib/security/bot-detection";
+import { trackRequest } from "@/lib/security/anomaly-detection";
+import { logFormSubmission } from "@/lib/security/audit-log";
+import { appendSubscriber } from "@/lib/google-sheets";
+import { hashEmail, generateLeadId } from "@/lib/security/email-hashing";
+import crypto from "crypto";
 
 // Lead storage interface
 interface LeadRecord {
@@ -45,31 +45,34 @@ export async function GET(request: NextRequest) {
     const securityResult = await securityCheck(request);
     if (!securityResult.allowed) {
       return NextResponse.json(
-        { error: 'Forbidden', message: securityResult.reason },
-        { status: 403 }
+        { error: "Forbidden", message: securityResult.reason },
+        { status: 403 },
       );
     }
 
     // Check for admin API key
-    const apiKey = request.headers.get('x-api-key');
+    const apiKey = request.headers.get("x-api-key");
     const adminApiKey = process.env.ADMIN_API_KEY;
-    
+
     if (!adminApiKey || apiKey !== adminApiKey) {
-      await trackRequest(ip, path, 'GET', 401, request.headers.get('user-agent') || '');
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
+      await trackRequest(
+        ip,
+        path,
+        "GET",
+        401,
+        request.headers.get("user-agent") || "",
       );
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     // Parse query params for filtering
     const { searchParams } = new URL(request.url);
-    const startDate = searchParams.get('start_date');
-    const endDate = searchParams.get('end_date');
-    const variant = searchParams.get('variant');
-    const geoCountry = searchParams.get('geo_country');
-    const source = searchParams.get('source');
-    const format = searchParams.get('format') || 'json';
+    const startDate = searchParams.get("start_date");
+    const endDate = searchParams.get("end_date");
+    const variant = searchParams.get("variant");
+    const geoCountry = searchParams.get("geo_country");
+    const source = searchParams.get("source");
+    const format = searchParams.get("format") || "json";
 
     // Convert leads map to array
     let filteredLeads = Array.from(leadsStorage.values());
@@ -77,34 +80,44 @@ export async function GET(request: NextRequest) {
     // Apply filters
     if (startDate) {
       const start = new Date(startDate);
-      filteredLeads = filteredLeads.filter(lead => new Date(lead.created_at) >= start);
+      filteredLeads = filteredLeads.filter(
+        (lead) => new Date(lead.created_at) >= start,
+      );
     }
 
     if (endDate) {
       const end = new Date(endDate);
-      filteredLeads = filteredLeads.filter(lead => new Date(lead.created_at) <= end);
+      filteredLeads = filteredLeads.filter(
+        (lead) => new Date(lead.created_at) <= end,
+      );
     }
 
     if (variant) {
-      filteredLeads = filteredLeads.filter(lead => lead.variant === variant);
+      filteredLeads = filteredLeads.filter((lead) => lead.variant === variant);
     }
 
     if (geoCountry) {
-      filteredLeads = filteredLeads.filter(lead => lead.geo_country === geoCountry);
+      filteredLeads = filteredLeads.filter(
+        (lead) => lead.geo_country === geoCountry,
+      );
     }
 
     if (source) {
-      filteredLeads = filteredLeads.filter(lead => lead.source === source);
+      filteredLeads = filteredLeads.filter((lead) => lead.source === source);
     }
 
     // Calculate comprehensive analytics
     const totalLeads = filteredLeads.length;
-    const convertedLeads = filteredLeads.filter(lead => lead.converted).length;
-    const conversionRate = totalLeads > 0 ? (convertedLeads / totalLeads) * 100 : 0;
+    const convertedLeads = filteredLeads.filter(
+      (lead) => lead.converted,
+    ).length;
+    const conversionRate =
+      totalLeads > 0 ? (convertedLeads / totalLeads) * 100 : 0;
 
     // Group by variant
-    const leadsByVariant: Record<string, { total: number; converted: number }> = {};
-    filteredLeads.forEach(lead => {
+    const leadsByVariant: Record<string, { total: number; converted: number }> =
+      {};
+    filteredLeads.forEach((lead) => {
       if (!leadsByVariant[lead.variant]) {
         leadsByVariant[lead.variant] = { total: 0, converted: 0 };
       }
@@ -116,8 +129,8 @@ export async function GET(request: NextRequest) {
 
     // Group by geo country
     const leadsByGeo: Record<string, { total: number; converted: number }> = {};
-    filteredLeads.forEach(lead => {
-      const country = lead.geo_country || 'unknown';
+    filteredLeads.forEach((lead) => {
+      const country = lead.geo_country || "unknown";
       if (!leadsByGeo[country]) {
         leadsByGeo[country] = { total: 0, converted: 0 };
       }
@@ -128,8 +141,9 @@ export async function GET(request: NextRequest) {
     });
 
     // Group by source
-    const leadsBySource: Record<string, { total: number; converted: number }> = {};
-    filteredLeads.forEach(lead => {
+    const leadsBySource: Record<string, { total: number; converted: number }> =
+      {};
+    filteredLeads.forEach((lead) => {
       if (!leadsBySource[lead.source]) {
         leadsBySource[lead.source] = { total: 0, converted: 0 };
       }
@@ -142,17 +156,19 @@ export async function GET(request: NextRequest) {
     // Calculate conversion rate by variant
     const variantConversionRates: Record<string, number> = {};
     Object.entries(leadsByVariant).forEach(([variantName, data]) => {
-      variantConversionRates[variantName] = data.total > 0 
-        ? Math.round((data.converted / data.total) * 10000) / 100 
-        : 0;
+      variantConversionRates[variantName] =
+        data.total > 0
+          ? Math.round((data.converted / data.total) * 10000) / 100
+          : 0;
     });
 
     // Calculate geo conversion rates
     const geoConversionRates: Record<string, number> = {};
     Object.entries(leadsByGeo).forEach(([country, data]) => {
-      geoConversionRates[country] = data.total > 0 
-        ? Math.round((data.converted / data.total) * 10000) / 100 
-        : 0;
+      geoConversionRates[country] =
+        data.total > 0
+          ? Math.round((data.converted / data.total) * 10000) / 100
+          : 0;
     });
 
     const analytics = {
@@ -168,18 +184,18 @@ export async function GET(request: NextRequest) {
       geo_conversion_rates: geoConversionRates,
       by_source: leadsBySource,
       period: {
-        start: startDate || 'all_time',
+        start: startDate || "all_time",
         end: endDate || new Date().toISOString(),
       },
     };
 
     // Return in requested format
-    if (format === 'csv') {
+    if (format === "csv") {
       const csv = generateCSV(filteredLeads);
       return new NextResponse(csv, {
         headers: {
-          'Content-Type': 'text/csv',
-          'Content-Disposition': 'attachment; filename="exit-intent-leads.csv"',
+          "Content-Type": "text/csv",
+          "Content-Disposition": 'attachment; filename="exit-intent-leads.csv"',
         },
       });
     }
@@ -190,11 +206,17 @@ export async function GET(request: NextRequest) {
       generated_at: new Date().toISOString(),
     });
   } catch (error) {
-    console.error('Error fetching lead analytics:', error);
-    await trackRequest(ip, path, 'GET', 500, request.headers.get('user-agent') || '');
+    console.error("Error fetching lead analytics:", error);
+    await trackRequest(
+      ip,
+      path,
+      "GET",
+      500,
+      request.headers.get("user-agent") || "",
+    );
     return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
+      { error: "Internal server error" },
+      { status: 500 },
     );
   }
 }
@@ -205,34 +227,38 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   const ip = getClientIP(request);
-  const userAgent = request.headers.get('user-agent') || '';
+  const userAgent = request.headers.get("user-agent") || "";
   const path = request.nextUrl.pathname;
-  const referrer = request.headers.get('referer') || '';
+  const referrer = request.headers.get("referer") || "";
 
   try {
     // Security check
     const securityResult = await securityCheck(request);
-    
+
     if (!securityResult.allowed) {
-      if (securityResult.challenge === 'block') {
+      if (securityResult.challenge === "block") {
         return NextResponse.json(
-          { error: 'Forbidden', message: securityResult.reason },
-          { status: 403 }
+          { error: "Forbidden", message: securityResult.reason },
+          { status: 403 },
         );
       }
       return NextResponse.json(
-        { error: 'Verification Required', message: securityResult.reason, requiresCaptcha: true },
-        { status: 429 }
+        {
+          error: "Verification Required",
+          message: securityResult.reason,
+          requiresCaptcha: true,
+        },
+        { status: 429 },
       );
     }
 
     const body = await request.json();
-    const { 
-      email, 
-      original_email_hash, 
-      variant = 'default', 
-      source = 'exit_intent_modal',
-      geo_country = 'unknown',
+    const {
+      email,
+      original_email_hash,
+      variant = "default",
+      source = "exit_intent_modal",
+      geo_country = "unknown",
       geo_offer_code = null,
       experiment_id = null,
       session_id = null,
@@ -243,44 +269,54 @@ export async function POST(request: NextRequest) {
 
     // Validate required fields
     if (!email && !original_email_hash) {
-      await trackRequest(ip, path, 'POST', 400, userAgent);
+      await trackRequest(ip, path, "POST", 400, userAgent);
       return NextResponse.json(
-        { error: 'Missing email or email hash' },
-        { status: 400 }
+        { error: "Missing email or email hash" },
+        { status: 400 },
       );
     }
 
     // Use provided hash or hash the email
-    const emailHash = original_email_hash || (email ? await hashEmail(email) : '');
-    
+    const emailHash =
+      original_email_hash || (email ? await hashEmail(email) : "");
+
     if (!emailHash) {
-      await trackRequest(ip, path, 'POST', 400, userAgent);
+      await trackRequest(ip, path, "POST", 400, userAgent);
       return NextResponse.json(
-        { error: 'Invalid email hash' },
-        { status: 400 }
+        { error: "Invalid email hash" },
+        { status: 400 },
       );
     }
 
     // Rate limiting for lead submission
-    const { checkRateLimit } = await import('@/lib/security/rate-limiter');
-    const { RATE_LIMITS } = await import('@/lib/security/rate-limit-config');
+    const { checkRateLimit } = await import("@/lib/security/rate-limiter");
+    const { RATE_LIMITS } = await import("@/lib/security/rate-limit-config");
     const rateLimitKey = `leads:${ip}`;
     const rateLimit = await checkRateLimit(
       rateLimitKey,
       RATE_LIMITS.API.subscribe.requests,
-      RATE_LIMITS.API.subscribe.windowSeconds
+      RATE_LIMITS.API.subscribe.windowSeconds,
     );
 
     if (!rateLimit.allowed) {
       return NextResponse.json(
-        { error: 'Too many submission attempts', message: 'Please try again later' },
-        { status: 429, headers: createRateLimitHeaders(rateLimit.remaining, rateLimit.resetTime) }
+        {
+          error: "Too many submission attempts",
+          message: "Please try again later",
+        },
+        {
+          status: 429,
+          headers: createRateLimitHeaders(
+            rateLimit.remaining,
+            rateLimit.resetTime,
+          ),
+        },
       );
     }
 
     // Check for duplicate leads (already subscribed)
     const existingLead = Array.from(leadsStorage.values()).find(
-      lead => lead.email_hash === emailHash
+      (lead) => lead.email_hash === emailHash,
     );
 
     if (existingLead) {
@@ -291,13 +327,13 @@ export async function POST(request: NextRequest) {
       }
 
       return NextResponse.json(
-        { 
-          message: 'Already subscribed',
+        {
+          message: "Already subscribed",
           duplicate: true,
           lead_id: existingLead.lead_id,
           was_converted: existingLead.converted,
         },
-        { status: 200 }
+        { status: 200 },
       );
     }
 
@@ -312,7 +348,11 @@ export async function POST(request: NextRequest) {
       geo_country,
       geo_offer_code,
       created_at: new Date().toISOString(),
-      ip_hash: crypto.createHash('sha256').update(ip).digest('hex').substring(0, 16),
+      ip_hash: crypto
+        .createHash("sha256")
+        .update(ip)
+        .digest("hex")
+        .substring(0, 16),
       user_agent: userAgent.substring(0, 200),
       converted: true,
       converted_at: new Date().toISOString(),
@@ -331,44 +371,73 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        console.log(
+          `[EXIT INTENT LEAD] New lead appended to Google Sheets: lead_${leadId.substring(5)} at ${new Date().toISOString()}`,
+        );
+      } else {
+        console.warn(
+          "GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.",
+        );
+        console.log(
+          `[EXIT INTENT LEAD FALLBACK] New lead recorded locally: lead_${leadId.substring(5)}`,
+        );
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      const errorMsg =
+        sheetsError instanceof Error
+          ? sheetsError.message
+          : String(sheetsError);
+      if (
+        errorMsg.includes("not configured") ||
+        errorMsg.includes("is not set")
+      ) {
+        console.warn(
+          `[EXIT INTENT LEAD FALLBACK] Google Sheets not configured. Lead recorded locally: lead_${leadId.substring(5)}`,
+        );
+      } else {
+        console.warn(
+          "Google Sheets append failed, falling back to local logging:",
+          sheetsError,
+        );
+        console.log(
+          `[EXIT INTENT LEAD FALLBACK] New lead recorded locally: lead_${leadId.substring(5)}`,
+        );
+      }
     }
 
-    // Log the submission
-    console.log(`[EXIT INTENT LEAD] New lead captured:
+    // Log the submission details
+    console.log(`[EXIT INTENT LEAD] New lead captured details:
       Lead ID: ${leadId}
       Variant: ${variant}
       Source: ${source}
       Geo: ${geo_country}
-      Offer Code: ${geo_offer_code || 'none'}
-      Experiment: ${experiment_id || 'none'}
+      Offer Code: ${geo_offer_code || "none"}
+      Experiment: ${experiment_id || "none"}
       Time: ${leadRecord.created_at}
     `);
 
-    await trackRequest(ip, path, 'POST', 200, userAgent);
-    await logFormSubmission(ip, path, 'exit_intent_lead', false, userAgent);
+    await trackRequest(ip, path, "POST", 200, userAgent);
+    await logFormSubmission(ip, path, "exit_intent_lead", false, userAgent);
 
     return NextResponse.json(
       {
         success: true,
-        message: 'Lead captured successfully',
+        message: "Lead captured successfully",
         lead_id: leadId,
         conversion_rate: calculateCurrentConversionRate(),
       },
       {
         status: 200,
-        headers: createRateLimitHeaders(rateLimit.remaining, rateLimit.resetTime),
-      }
+        headers: createRateLimitHeaders(
+          rateLimit.remaining,
+          rateLimit.resetTime,
+        ),
+      },
     );
   } catch (error) {
-    console.error('Error processing exit intent lead:', error);
-    await trackRequest(ip, path, 'POST', 400, userAgent);
-    return NextResponse.json(
-      { error: 'Bad Request' },
-      { status: 400 }
-    );
+    console.error("Error processing exit intent lead:", error);
+    await trackRequest(ip, path, "POST", 400, userAgent);
+    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
   }
 }
 
@@ -378,7 +447,7 @@ export async function POST(request: NextRequest) {
  */
 export async function PATCH(request: NextRequest) {
   const ip = getClientIP(request);
-  const userAgent = request.headers.get('user-agent') || '';
+  const userAgent = request.headers.get("user-agent") || "";
   const path = request.nextUrl.pathname;
 
   try {
@@ -386,39 +455,36 @@ export async function PATCH(request: NextRequest) {
     const securityResult = await securityCheck(request);
     if (!securityResult.allowed) {
       return NextResponse.json(
-        { error: 'Forbidden', message: securityResult.reason },
-        { status: 403 }
+        { error: "Forbidden", message: securityResult.reason },
+        { status: 403 },
       );
     }
 
     // Check for admin API key
-    const apiKey = request.headers.get('x-api-key');
+    const apiKey = request.headers.get("x-api-key");
     const adminApiKey = process.env.ADMIN_API_KEY;
-    
+
     if (!adminApiKey || apiKey !== adminApiKey) {
-      await trackRequest(ip, path, 'PATCH', 401, request.headers.get('user-agent') || '');
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
+      await trackRequest(
+        ip,
+        path,
+        "PATCH",
+        401,
+        request.headers.get("user-agent") || "",
       );
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const body = await request.json();
     const { lead_id, converted = true } = body;
 
     if (!lead_id) {
-      return NextResponse.json(
-        { error: 'Missing lead_id' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Missing lead_id" }, { status: 400 });
     }
 
     const lead = leadsStorage.get(lead_id);
     if (!lead) {
-      return NextResponse.json(
-        { error: 'Lead not found' },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: "Lead not found" }, { status: 404 });
     }
 
     lead.converted = converted;
@@ -426,7 +492,7 @@ export async function PATCH(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      message: 'Lead updated successfully',
+      message: "Lead updated successfully",
       lead: {
         lead_id: lead.lead_id,
         converted: lead.converted,
@@ -434,10 +500,10 @@ export async function PATCH(request: NextRequest) {
       },
     });
   } catch (error) {
-    console.error('Error updating lead:', error);
+    console.error("Error updating lead:", error);
     return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
+      { error: "Internal server error" },
+      { status: 500 },
     );
   }
 }
@@ -448,8 +514,8 @@ export async function PATCH(request: NextRequest) {
 function calculateCurrentConversionRate(): number {
   const leads = Array.from(leadsStorage.values());
   if (leads.length === 0) return 0;
-  
-  const converted = leads.filter(l => l.converted).length;
+
+  const converted = leads.filter((l) => l.converted).length;
   return Math.round((converted / leads.length) * 10000) / 100;
 }
 
@@ -458,34 +524,34 @@ function calculateCurrentConversionRate(): number {
  */
 function generateCSV(leads: LeadRecord[]): string {
   const headers = [
-    'lead_id',
-    'email_hash',
-    'variant',
-    'source',
-    'geo_country',
-    'geo_offer_code',
-    'created_at',
-    'converted',
-    'converted_at',
-    'experiment_id',
-    'session_id',
-    'referrer',
+    "lead_id",
+    "email_hash",
+    "variant",
+    "source",
+    "geo_country",
+    "geo_offer_code",
+    "created_at",
+    "converted",
+    "converted_at",
+    "experiment_id",
+    "session_id",
+    "referrer",
   ];
 
-  const rows = leads.map(lead => [
+  const rows = leads.map((lead) => [
     lead.lead_id,
     lead.email_hash,
     lead.variant,
     lead.source,
     lead.geo_country,
-    lead.geo_offer_code || '',
+    lead.geo_offer_code || "",
     lead.created_at,
     lead.converted.toString(),
-    lead.converted_at || '',
-    lead.experiment_id || '',
+    lead.converted_at || "",
+    lead.experiment_id || "",
     lead.session_id,
     lead.referrer,
   ]);
 
-  return [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
+  return [headers.join(","), ...rows.map((r) => r.join(","))].join("\n");
 }


### PR DESCRIPTION
In `src/app/api/leads/exit-intent/route.ts`, if `GOOGLE_SERVICE_ACCOUNT_JSON` was missing, the code would silently fail or log a generic error during append.
This patch updates the logic to properly check if the credential exists before attempting to append. It also handles actual insertion errors versus missing configuration distinctly, logging explicit `[EXIT INTENT LEAD FALLBACK]` warnings for better admin visibility, consistent with other fallback implementations in the repository.

---
*PR created automatically by Jules for task [9615562924669286299](https://jules.google.com/task/9615562924669286299) started by @yuga-hashimoto*