### PR TITLE
📝 Content Sync: Refresh alibaba-coding-plan

### DIFF
--- a/content/tools/en/alibaba-coding-plan.md
+++ b/content/tools/en/alibaba-coding-plan.md
@@ -13,11 +13,11 @@ cons:
   - "Primarily designed for interactive coding tools rather than generic automation"
 affiliate_link: "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
 pricing: "paid"
-price: "Starter $10 / Pro $50"
+price: "Pro $50/mo (Starter discontinued)"
 platform:
   - "Web"
   - "Desktop"
-last_updated: "2026-03-07"
+last_updated: "2026-03-31"
 verified: true
 ---
 
@@ -33,7 +33,7 @@ Alibaba provides an official setup path for Qwen Code, including dedicated CLI a
 
 ### 2. Predictable pricing
 
-The public plan overview lists Starter and Pro tiers, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
+The public plan overview lists a $50/month Pro tier, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage. (Note: The $10 Starter/Lite tier was discontinued in March 2026).
 
 ### 3. Multi-model support
 

--- a/content/tools/ja/alibaba-coding-plan.md
+++ b/content/tools/ja/alibaba-coding-plan.md
@@ -13,11 +13,11 @@ cons:
   - '汎用 API 自動化より対話型コーディングツール向け'
 affiliate_link: 'https://www.alibabacloud.com/help/ja/model-studio/coding-plan'
 pricing: 'paid'
-price: 'Starter $10 / Pro $50'
+price: 'Pro $50/月 (Starter廃止)'
 platform:
   - 'Web'
   - 'Desktop'
-last_updated: '2026-03-07'
+last_updated: '2026-03-31'
 verified: true
 ---
 
@@ -33,7 +33,7 @@ Alibaba 側が Qwen Code の公式ガイドを用意しており、CLI やエデ
 
 ### 2. 月額制で回しやすい
 
-Starter / Pro のようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
+Proプランの定額課金（$50/月）なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。（※$10のStarter/Liteプランは2026年3月に新規受付を終了しました）
 
 ### 3. 複数モデルを選べる
 


### PR DESCRIPTION
This PR updates the pricing information and content for the `alibaba-coding-plan` tool.

Based on recent content sync data, Alibaba Cloud Model Studio discontinued their Lite/Starter tier ($10) on March 20, 2026. This PR updates the tool's pricing metadata to accurately reflect that only the Pro tier ($50/month) is now available.

**Changes:**
- `content/tools/en/alibaba-coding-plan.md`: Updated `price` metadata, updated section 2 in the body to explicitly mention the $50 tier and the discontinuation of the Starter tier.
- `content/tools/ja/alibaba-coding-plan.md`: Translated the same updates for the Japanese site.
- Cleaned up local test artifacts before submitting.

---
*PR created automatically by Jules for task [13085624941726068427](https://jules.google.com/task/13085624941726068427) started by @yuga-hashimoto*