### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -10,6 +10,7 @@ import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
 import { getComparePresetBySlug, parseComparisonSlug } from "@/lib/compare-pages";
 import { getEditorialToolStatus, isReviewPendingToolSlug } from "@/lib/editorial";
 import { Link } from "@/i18n/routing";
+import { ExternalLink } from "lucide-react";
 
 interface PageParams {
   locale: string;
@@ -283,9 +284,10 @@ export default async function CompareTemplatePage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position={`compare_template_${comparisonSlug}`}
-                            className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
+                            className="group inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-1.5 h-4 w-4 transition-transform group-hover:translate-x-0.5" />
                           </AffiliateLinkButton>
                         </div>
                       </td>


### PR DESCRIPTION
Added an external link icon and subtle hover transition to the outbound affiliate CTA buttons on the preset comparison pages to improve clarity and user trust.

---
*PR created automatically by Jules for task [7286789448978385186](https://jules.google.com/task/7286789448978385186) started by @yuga-hashimoto*