### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -9,6 +9,7 @@ import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
+import { ArrowRight } from "lucide-react";
 
 export async function generateMetadata({
   params,
@@ -19,7 +20,9 @@ export async function generateMetadata({
   const isJapanese = locale === "ja";
 
   return {
-    title: isJapanese ? "AIツール比較ハブ | AI Tool Navigator" : "Compare AI Tools | AI Tool Navigator",
+    title: isJapanese
+      ? "AIツール比較ハブ | AI Tool Navigator"
+      : "Compare AI Tools | AI Tool Navigator",
     description: isJapanese
       ? "主要AIツールを横並びで比較。価格、検証状況、長所短所を確認し、最適なAIソリューションを見つけましょう。"
       : "Compare leading AI tools side-by-side. Evaluate features, pricing, review status, and pros/cons to find the best AI solution for your workflow.",
@@ -36,7 +39,9 @@ export default async function ComparePage({
 }) {
   const { locale } = await params;
   const isJapanese = locale === "ja";
-  const tools = filterToolList(await getAllTools(locale)).sort(sortToolsForEditorialLists);
+  const tools = filterToolList(await getAllTools(locale)).sort(
+    sortToolsForEditorialLists,
+  );
   const tBreadcrumbs = await getTranslations("Breadcrumbs");
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -123,12 +128,17 @@ export default async function ComparePage({
               <Link
                 key={preset.title}
                 href={preset.href}
-                className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                className="group rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
               >
-                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">{preset.title}</h3>
-                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">{preset.description}</p>
-                <div className="mt-5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">
+                  {preset.title}
+                </h3>
+                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                  {preset.description}
+                </p>
+                <div className="mt-5 inline-flex items-center text-sm font-semibold text-blue-600 dark:text-blue-400 group-hover:text-blue-500">
                   {copy.presetCta}
+                  <ArrowRight className="ml-1.5 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </div>
               </Link>
             ))}


### PR DESCRIPTION
I've improved the internal linking/CTA clarity on the Compare Page (`/compare`). The comparison presets were previously acting as simple links with plain text `Compare this set`. 

This change adds the `group` class to the cards and implements an `inline-flex` layout on the text container, adding a `lucide-react` `ArrowRight` icon with a clean CSS hover transition (`group-hover:translate-x-1` and `group-hover:text-blue-500`). This significantly enhances the visual cues, making the cards feel distinctly clickable and directing the user clearly toward comparing the chosen set. 

This directly addresses the Revenue Optimizer objective of improving CTA clarity to encourage high-intent actions. The E2E tests pass cleanly and I've verified the UI renders beautifully across screen sizes.

---
*PR created automatically by Jules for task [325994681353544399](https://jules.google.com/task/325994681353544399) started by @yuga-hashimoto*