### PR TITLE
📝 Content Sync: Refresh Alibaba Cloud Model Studio Coding Plan

### DIFF
--- a/content/tools/en/alibaba-coding-plan.md
+++ b/content/tools/en/alibaba-coding-plan.md
@@ -13,7 +13,7 @@ cons:
   - "Primarily designed for interactive coding tools rather than generic automation"
 affiliate_link: "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
 pricing: "paid"
-price: "Starter $10 / Pro $50"
+price: "Pro $50"
 platform:
   - "Web"
   - "Desktop"
@@ -33,7 +33,7 @@ Alibaba provides an official setup path for Qwen Code, including dedicated CLI a
 
 ### 2. Predictable pricing
 
-The public plan overview lists Starter and Pro tiers, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
+The public plan overview lists the Pro tier, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
 
 ### 3. Multi-model support
 

--- a/content/tools/ja/alibaba-coding-plan.md
+++ b/content/tools/ja/alibaba-coding-plan.md
@@ -6,14 +6,14 @@ description: 'Alibaba Cloud の定額型 Coding Plan。Qwen Code、Claude Code�
 rating: 4.7
 pros:
   - 'Qwen Code の公式導線が強く CLI と拡張機能の両方が揃う'
-  - 'Starter / Pro の月額制で予算管理しやすい'
+  - 'Proプランの月額制で予算管理しやすい'
   - 'Qwen 系だけでなく複数モデルを使い分けやすい'
 cons:
   - '通常の Model Studio API とはキーと Base URL が別'
   - '汎用 API 自動化より対話型コーディングツール向け'
 affiliate_link: 'https://www.alibabacloud.com/help/ja/model-studio/coding-plan'
 pricing: 'paid'
-price: 'Starter $10 / Pro $50'
+price: 'Pro $50'
 platform:
   - 'Web'
   - 'Desktop'
@@ -33,7 +33,7 @@ Alibaba 側が Qwen Code の公式ガイドを用意しており、CLI やエデ
 
 ### 2. 月額制で回しやすい
 
-Starter / Pro のようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
+Proのようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
 
 ### 3. 複数モデルを選べる
 


### PR DESCRIPTION
Updated Alibaba Cloud Model Studio Coding Plan details across English and Japanese markdown content based on automated sync data. Removed references to the discontinued Starter $10 tier and updated pricing to reflect the Pro $50 plan as the primary offering.

---
*PR created automatically by Jules for task [4598484609620651390](https://jules.google.com/task/4598484609620651390) started by @yuga-hashimoto*