### PR TITLE
💰 Revenue Optimizer: Improve CTA clarity on category and comparison pages

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { ArrowRight, ExternalLink } from "lucide-react";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -233,16 +234,18 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="inline-flex items-center group rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link
                   href="/tools"
-                  className="inline-flex items-center rounded-full border border-zinc-300 px-6 py-3 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
+                  className="inline-flex items-center group rounded-full border border-zinc-300 px-6 py-3 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
                 >
                   {copy.browseAllCta}
+                  <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Link>
               </div>
             </div>
@@ -347,9 +350,10 @@ export default async function CategoryPage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position="category_compare_table"
-                            className="text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
+                            className="inline-flex items-center text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
                           >
                             {copy.visitLabel}
+                            <ExternalLink className="ml-1 h-3 w-3" />
                           </AffiliateLinkButton>
                         </div>
                       </td>

--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -6,6 +6,7 @@ import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { getAllTools, ToolMetadata } from "@/lib/tools";
+import { ExternalLink } from "lucide-react";
 import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
 import { getComparePresetBySlug, parseComparisonSlug } from "@/lib/compare-pages";
 import { getEditorialToolStatus, isReviewPendingToolSlug } from "@/lib/editorial";
@@ -286,6 +287,7 @@ export default async function CompareTemplatePage({
                             className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-2 h-4 w-4" />
                           </AffiliateLinkButton>
                         </div>
                       </td>

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -9,6 +9,7 @@ import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
+import { ArrowRight } from "lucide-react";
 
 export async function generateMetadata({
   params,
@@ -123,12 +124,13 @@ export default async function ComparePage({
               <Link
                 key={preset.title}
                 href={preset.href}
-                className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                className="group rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
               >
                 <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">{preset.title}</h3>
                 <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">{preset.description}</p>
-                <div className="mt-5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                <div className="mt-5 inline-flex items-center text-sm font-semibold text-blue-600 dark:text-blue-400">
                   {copy.presetCta}
+                  <ArrowRight className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </div>
               </Link>
             ))}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
This PR adds contextual icons (`ArrowRight` for internal navigation and `ExternalLink` for outbound affiliate links) to Call-To-Action (CTA) buttons on the category landing page, comparison hub, and comparison preset pages. These small visual cues help clarify the expected action for the user before they click, which can improve click-through rates and overall user experience without relying on spammy tactics.

### Changes Made:
- **`src/app/[locale]/category/[slug]/page.tsx`**: Added `ArrowRight` with a hover translation effect to "Compare this category" and "Browse all tools" buttons. Added `ExternalLink` to the `AffiliateLinkButton` inside the compare table.
- **`src/app/[locale]/compare/page.tsx`**: Added `ArrowRight` with a hover translation effect to the preset comparison links.
- **`src/app/[locale]/compare/[comparisonSlug]/page.tsx`**: Added `ExternalLink` to the `AffiliateLinkButton` in the preset comparison table.

---
*PR created automatically by Jules for task [5961837848897835830](https://jules.google.com/task/5961837848897835830) started by @yuga-hashimoto*