### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior

### DIFF
--- a/src/app/api/partner-inquiry/route.ts
+++ b/src/app/api/partner-inquiry/route.ts
@@ -48,26 +48,25 @@ export async function POST(request: NextRequest) {
     });
 
     try {
-      await appendPartnerInquiry({
-        inquiryType: record.inquiryType,
-        companyName: record.companyName,
-        contactName: record.contactName,
-        email: record.email,
-        websiteUrl: record.websiteUrl,
-        packageInterest: record.packageInterest,
-        monthlyBudget: record.monthlyBudget,
-        message: record.message,
-        locale: record.locale,
-      });
-      console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
-    } catch (sheetError) {
-      const errorMsg = sheetError instanceof Error ? sheetError.message : String(sheetError);
-      if (errorMsg.includes('not configured')) {
-        console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
+      if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+        await appendPartnerInquiry({
+          inquiryType: record.inquiryType,
+          companyName: record.companyName,
+          contactName: record.contactName,
+          email: record.email,
+          websiteUrl: record.websiteUrl,
+          packageInterest: record.packageInterest,
+          monthlyBudget: record.monthlyBudget,
+          message: record.message,
+          locale: record.locale,
+        });
+        console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
       } else {
-        console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
-        console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
+        console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
       }
+    } catch (sheetError) {
+      console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
+      console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
     }
 
     return NextResponse.json({

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -76,10 +76,16 @@ export async function POST(request: NextRequest) {
 
     try {
       try {
-        await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
-        console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+          await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
+          console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        } else {
+          console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+          console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
+          console.log('Submission data:', { name, url, description, category, pricing_model, price });
+        }
       } catch (sheetError) {
-        console.warn('Google Sheets append failed or not configured, falling back to local logging:', sheetError);
+        console.warn('Google Sheets append failed, falling back to local logging:', sheetError);
         console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
         console.log('Submission data:', { name, url, description, category, pricing_model, price });
       }


### PR DESCRIPTION
Update `src/app/api/partner-inquiry/route.ts` and `src/app/api/submit/route.ts` to explicitly check for `process.env.GOOGLE_SERVICE_ACCOUNT_JSON` before calling Google Sheets append methods, ensuring consistent fallback behavior without relying on catching string errors.

---
*PR created automatically by Jules for task [10293887827051570039](https://jules.google.com/task/10293887827051570039) started by @yuga-hashimoto*