### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getCategoryLandingContent } from "@/lib/category-landing";
 import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
+import { ArrowRight, ExternalLink } from "lucide-react";
 
 export async function generateStaticParams() {
   return Object.keys(CATEGORY_MAPPINGS).map((slug) => ({
@@ -23,7 +24,11 @@ export async function generateStaticParams() {
   }));
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
   const { slug, locale } = await params;
 
   if (!Object.keys(CATEGORY_MAPPINGS).includes(slug)) {
@@ -77,25 +82,26 @@ function formatUpdatedDate(value: string | undefined, locale: string): string {
 function formatPricingLabel(
   locale: string,
   price: string | undefined,
-  pricing: "free" | "freemium" | "paid" | "contact" | undefined
+  pricing: "free" | "freemium" | "paid" | "contact" | undefined,
 ): string {
   if (price) {
     return price;
   }
 
-  const labels = locale === "ja"
-    ? {
-        free: "無料",
-        freemium: "フリーミアム",
-        paid: "有料",
-        contact: "要問い合わせ",
-      }
-    : {
-        free: "Free",
-        freemium: "Freemium",
-        paid: "Paid",
-        contact: "Contact sales",
-      };
+  const labels =
+    locale === "ja"
+      ? {
+          free: "無料",
+          freemium: "フリーミアム",
+          paid: "有料",
+          contact: "要問い合わせ",
+        }
+      : {
+          free: "Free",
+          freemium: "Freemium",
+          paid: "Paid",
+          contact: "Contact sales",
+        };
 
   return pricing ? labels[pricing] : locale === "ja" ? "未掲載" : "Not listed";
 }
@@ -115,18 +121,24 @@ export default async function CategoryPage({
   const t = await getTranslations("CategoryPage");
   const tBreadcrumbs = await getTranslations("Breadcrumbs");
 
-  const targetCategories = CATEGORY_MAPPINGS[slug as keyof typeof CATEGORY_MAPPINGS];
+  const targetCategories =
+    CATEGORY_MAPPINGS[slug as keyof typeof CATEGORY_MAPPINGS];
   const tools = await getAllTools(locale);
   const filteredTools = filterToolList(
-    tools.filter((tool) => targetCategories.includes(tool.category))
+    tools.filter((tool) => targetCategories.includes(tool.category)),
   ).sort(sortToolsForEditorialLists);
 
   const title = t(`${slug}_title` as never);
   const description = t(`${slug}_description` as never);
-  const landing = getCategoryLandingContent(slug, isJapanese ? "ja" : "en", title);
+  const landing = getCategoryLandingContent(
+    slug,
+    isJapanese ? "ja" : "en",
+    title,
+  );
   const featuredTools = filteredTools.slice(0, 5);
   const compareSlugs = featuredTools.slice(0, 3).map((tool) => tool.slug);
-  const compareHref = compareSlugs.length >= 2 ? getComparisonHref(compareSlugs) : null;
+  const compareHref =
+    compareSlugs.length >= 2 ? getComparisonHref(compareSlugs) : null;
   const verifiedCount = filteredTools.filter((tool) => tool.verified).length;
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -233,9 +245,10 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="group inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link
@@ -253,7 +266,10 @@ export default async function CategoryPage({
               </h2>
               <ul className="mt-5 space-y-4">
                 {landing.selectionPoints.map((point) => (
-                  <li key={point} className="flex gap-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                  <li
+                    key={point}
+                    className="flex gap-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400"
+                  >
                     <span className="mt-2 h-2.5 w-2.5 flex-none rounded-full bg-blue-600 dark:bg-blue-400" />
                     <span>{point}</span>
                   </li>
@@ -313,10 +329,16 @@ export default async function CategoryPage({
                   {featuredTools.map((tool) => (
                     <tr key={tool.slug} className="align-top">
                       <td className="px-6 py-4">
-                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">{tool.title}</div>
-                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{tool.description}</div>
+                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">
+                          {tool.title}
+                        </div>
+                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                          {tool.description}
+                        </div>
                       </td>
-                      <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">{tool.rating ?? "-"}</td>
+                      <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">
+                        {tool.rating ?? "-"}
+                      </td>
                       <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">
                         {formatPricingLabel(locale, tool.price, tool.pricing)}
                       </td>
@@ -328,7 +350,9 @@ export default async function CategoryPage({
                               : "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/30"
                           }`}
                         >
-                          {tool.verified ? copy.statusVerified : copy.statusPending}
+                          {tool.verified
+                            ? copy.statusVerified
+                            : copy.statusPending}
                         </span>
                       </td>
                       <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">
@@ -347,9 +371,10 @@ export default async function CategoryPage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position="category_compare_table"
-                            className="text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
+                            className="inline-flex items-center text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
                           >
                             {copy.visitLabel}
+                            <ExternalLink className="ml-1 h-3 w-3" />
                           </AffiliateLinkButton>
                         </div>
                       </td>


### PR DESCRIPTION
This PR improves the visual clarity of internal and outbound Call-to-Action (CTA) buttons on category landing pages.

### Changes:
1. **Compare Category CTA:** Added an `ArrowRight` icon with a right-translate hover transition to emphasize internal navigation to the comparison view.
2. **Affiliate Link CTA:** Added an `ExternalLink` icon to the "Visit site" button in the comparison table to clearly indicate to users that the link leads to an external site, establishing better trust before a click.

These changes are designed to improve click-through rates by providing users with clear visual cues about what happens when they click a button.

---
*PR created automatically by Jules for task [2445143748909151671](https://jules.google.com/task/2445143748909151671) started by @yuga-hashimoto*