### PR TITLE
🧭 Trust Builder: Improve schema/metadata pricing accuracy

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === 'free' || metadata.pricing === 'freemium')) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR improves the JSON-LD schema generation in `src/lib/schema.ts` to increase editorial trust and prevent overclaiming in rich snippets.

Previously, an `Offer` object with `price: "0"` was hardcoded into the base schema generation, which incorrectly applied to all tools regardless of their actual pricing tier (e.g., paid enterprise tools).

Changes:
- Modified `generateProductSchema` to conditionally add the `$0` `Offer` only if `metadata.pricing === 'free'` or `metadata.pricing === 'freemium'`.
- Modified `generateToolSchema` to require both the presence of an `affiliate_link` AND the appropriate pricing tier before appending the `Offer` object.

---
*PR created automatically by Jules for task [15752749564671185887](https://jules.google.com/task/15752749564671185887) started by @yuga-hashimoto*