### PR TITLE
🌐 Localization: Fix missing SubmitPage keys

### DIFF
--- a/messages/ja.json
+++ b/messages/ja.json
@@ -46,6 +46,14 @@
       "url": "ウェブサイトURL",
       "description": "説明",
       "category": "カテゴリー",
+      "pricing_model": "料金モデル",
+      "pricing_model_options": {
+        "free": "無料",
+        "freemium": "フリーミアム",
+        "paid": "有料",
+        "contact": "要問い合わせ"
+      },
+      "price": "価格 (例: 月額$10)",
       "submit": "ツールを送信",
       "submitting": "送信中...",
       "success": "ツールが正常に送信されました！",


### PR DESCRIPTION
This PR adds the missing Japanese translation keys for pricing in the tool submission form `SubmitPage.form` within `messages/ja.json`. Previously, `pricing_model`, `pricing_model_options` (with mapped standard terminology like '無料', 'フリーミアム', '有料', '要問い合わせ'), and `price` were missing compared to the English locale. This change ensures form localization completeness and term consistency.

---
*PR created automatically by Jules for task [2510242696651388563](https://jules.google.com/task/2510242696651388563) started by @yuga-hashimoto*