### PR TITLE
💰 Revenue Optimizer: Improve category CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getCategoryLandingContent } from "@/lib/category-landing";
 import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
+import { ExternalLink, ArrowRight } from "lucide-react";
 
 export async function generateStaticParams() {
   return Object.keys(CATEGORY_MAPPINGS).map((slug) => ({
@@ -233,9 +234,10 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="inline-flex items-center group rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link
@@ -347,9 +349,10 @@ export default async function CategoryPage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position="category_compare_table"
-                            className="text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
+                            className="inline-flex items-center text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
                           >
                             {copy.visitLabel}
+                            <ExternalLink className="ml-1 h-3 w-3" />
                           </AffiliateLinkButton>
                         </div>
                       </td>


### PR DESCRIPTION
This patch improves the clarity and user experience of Call-To-Action (CTA) buttons on the category landing pages:
1.  **Compare CTA:** Added an `ArrowRight` icon with a hover animation (`group-hover:translate-x-1`) to draw attention and encourage users to interact with the dynamic comparison feature.
2.  **Affiliate Visit Link:** Added an `ExternalLink` icon and applied `inline-flex items-center` to the `AffiliateLinkButton` within the comparison table. This provides a clear visual cue that the link navigates away from the site, building trust and potentially improving click-through rates.

---
*PR created automatically by Jules for task [12521727951568669470](https://jules.google.com/task/12521727951568669470) started by @yuga-hashimoto*