### PR TITLE
🧭 Trust Builder: Improve schema/metadata improvements

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === 'free' || metadata.pricing === 'freemium')) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR fixes an issue where the `generateProductSchema` and `generateToolSchema` functions in `src/lib/schema.ts` were unconditionally emitting a `$0` `Offer` element in the JSON-LD payload.

For tools that are not free or freemium, this $0 price causes deceptive structured data, breaking Google's rich result guidelines and reducing user trust. This update wraps the `Offer` generation inside an `if (metadata.pricing === 'free' || metadata.pricing === 'freemium')` block so that only legitimately free or freemium tools declare a $0 price.

---
*PR created automatically by Jules for task [12132568181070381029](https://jules.google.com/task/12132568181070381029) started by @yuga-hashimoto*