### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior

### DIFF
--- a/src/app/api/partner-inquiry/route.ts
+++ b/src/app/api/partner-inquiry/route.ts
@@ -47,27 +47,26 @@ export async function POST(request: NextRequest) {
       locale: body.locale || "en",
     });
 
-    try {
-      await appendPartnerInquiry({
-        inquiryType: record.inquiryType,
-        companyName: record.companyName,
-        contactName: record.contactName,
-        email: record.email,
-        websiteUrl: record.websiteUrl,
-        packageInterest: record.packageInterest,
-        monthlyBudget: record.monthlyBudget,
-        message: record.message,
-        locale: record.locale,
-      });
-      console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
-    } catch (sheetError) {
-      const errorMsg = sheetError instanceof Error ? sheetError.message : String(sheetError);
-      if (errorMsg.includes('not configured')) {
-        console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
-      } else {
+    if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+      try {
+        await appendPartnerInquiry({
+          inquiryType: record.inquiryType,
+          companyName: record.companyName,
+          contactName: record.contactName,
+          email: record.email,
+          websiteUrl: record.websiteUrl,
+          packageInterest: record.packageInterest,
+          monthlyBudget: record.monthlyBudget,
+          message: record.message,
+          locale: record.locale,
+        });
+        console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
+      } catch (sheetError) {
         console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
         console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
       }
+    } else {
+      console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
     }
 
     return NextResponse.json({

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -75,11 +75,17 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      try {
-        await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
-        console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
-      } catch (sheetError) {
-        console.warn('Google Sheets append failed or not configured, falling back to local logging:', sheetError);
+      if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+        try {
+          await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
+          console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        } catch (sheetError) {
+          console.warn('Google Sheets append failed, falling back to local logging:', sheetError);
+          console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
+          console.log('Submission data:', { name, url, description, category, pricing_model, price });
+        }
+      } else {
+        console.warn('Google Sheets not configured, skipping append and falling back to local logging.');
         console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
         console.log('Submission data:', { name, url, description, category, pricing_model, price });
       }


### PR DESCRIPTION
This PR improves the reliability and clarity of the Google Sheets fallback behavior. Previously, the application relied on an exception being thrown and parsing its error string to determine if Google Sheets was unconfigured. This was fragile. Now, the logic explicitly checks `process.env.GOOGLE_SERVICE_ACCOUNT_JSON` before executing the insert function, leading to cleaner logs and more robust fallback processing for partner inquiries and tool submissions.

---
*PR created automatically by Jules for task [11421518585006713505](https://jules.google.com/task/11421518585006713505) started by @yuga-hashimoto*