### PR TITLE
🧭 Trust Builder: Improve schema pricing accuracy and review attribution

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -114,6 +117,22 @@ export function generateProductSchema(tool: Tool) {
       "reviewCount": metadata.rating_breakdown ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0) : 1,
       "bestRating": bestRating,
       "worstRating": "1"
+    };
+
+    schema.review = {
+      "@type": "Review",
+      "reviewRating": {
+        "@type": "Rating",
+        "ratingValue": metadata.rating,
+        "bestRating": bestRating,
+        "worstRating": "1"
+      },
+      "author": {
+        "@type": "Organization",
+        "name": "AI Tool Navigator"
+      },
+      "reviewBody": metadata.description,
+      "datePublished": metadata.last_updated || new Date().toISOString()
     };
   }
 
@@ -155,7 +174,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === 'free' || metadata.pricing === 'freemium')) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR improves the trust and accuracy of the generated Schema.org data for tools and products on the platform. 

Specifically, it ensures that the `Offer` object (which hardcodes a `$0` price for tools) is only included if the tool is actually marked as `'free'` or `'freemium'` in its metadata. Previously, paid tools were incorrectly outputting a `$0` offer schema, which could lead to deceptive rich snippets in search results.

Additionally, this PR explicitly attributes the reviews in `generateProductSchema` to the "AI Tool Navigator" organization, ensuring the structured data passes validation and properly signals editorial origin.

---
*PR created automatically by Jules for task [445228694052643724](https://jules.google.com/task/445228694052643724) started by @yuga-hashimoto*