### PR TITLE
🧭 Trust Builder: Improve schema/metadata

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -114,6 +117,22 @@ export function generateProductSchema(tool: Tool) {
       "reviewCount": metadata.rating_breakdown ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0) : 1,
       "bestRating": bestRating,
       "worstRating": "1"
+    };
+
+    schema.review = {
+      "@type": "Review",
+      "reviewRating": {
+        "@type": "Rating",
+        "ratingValue": metadata.rating,
+        "bestRating": bestRating,
+        "worstRating": "1"
+      },
+      "author": {
+        "@type": "Organization",
+        "name": "AI Tool Navigator"
+      },
+      "reviewBody": metadata.description,
+      "datePublished": metadata.last_updated || new Date().toISOString()
     };
   }
 
@@ -155,7 +174,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === 'free' || metadata.pricing === 'freemium')) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR improves editorial trust and structured data accuracy by addressing an issue where paid tools were inadvertently represented as having a $0 price in their schema.

Changes:
- Updates `generateProductSchema` and `generateToolSchema` in `src/lib/schema.ts` to only include the "0" priced `Offer` object if the metadata pricing model explicitly states "free" or "freemium".
- Adds an explicit `Review` object to `generateProductSchema` that maps the review ratings specifically to "AI Tool Navigator", matching existing trust paradigms in the repository's application schemas.

---
*PR created automatically by Jules for task [16766125224520449413](https://jules.google.com/task/16766125224520449413) started by @yuga-hashimoto*