### PR TITLE
🧭 Trust Builder: Improve affiliate disclosure on category pages

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -205,6 +206,9 @@ export default async function CategoryPage({
       />
       <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
         <Breadcrumbs items={breadcrumbItems} />
+        <div className="mb-6 mt-4">
+          <AffiliateDisclaimer variant="compact" />
+        </div>
 
         <section className="rounded-[2rem] border border-zinc-200 bg-zinc-50 p-8 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/60 sm:p-10">
           <div className="grid gap-8 lg:grid-cols-[1.1fr,0.9fr] lg:items-start">


### PR DESCRIPTION
This PR introduces an `AffiliateDisclaimer` to the category landing pages (`src/app/[locale]/category/[slug]/page.tsx`).

Category landing pages serve as a major discoverability hub and often feature comparison tables and tool links that may include affiliate parameters. Displaying an explicit affiliate disclosure right below the breadcrumbs on these pages improves transparency, clearly separates editorial intent from revenue mechanics, and builds long-term user trust by adhering to our stated editorial policy. 

This is a single, small, and targeted improvement focused on trust and transparency.

---
*PR created automatically by Jules for task [16697059309605409685](https://jules.google.com/task/16697059309605409685) started by @yuga-hashimoto*