### PR TITLE
📝 Content Sync: Refresh alibaba-coding-plan

### DIFF
--- a/content/tools/en/alibaba-coding-plan.md
+++ b/content/tools/en/alibaba-coding-plan.md
@@ -13,7 +13,7 @@ cons:
   - "Primarily designed for interactive coding tools rather than generic automation"
 affiliate_link: "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
 pricing: "paid"
-price: "Starter $10 / Pro $50"
+price: "Pro $50 /month"
 platform:
   - "Web"
   - "Desktop"
@@ -33,7 +33,7 @@ Alibaba provides an official setup path for Qwen Code, including dedicated CLI a
 
 ### 2. Predictable pricing
 
-The public plan overview lists Starter and Pro tiers, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
+The public plan overview lists the Pro tier at $50/month (the Lite plan is no longer accepting new subscriptions), which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
 
 ### 3. Multi-model support
 

--- a/content/tools/ja/alibaba-coding-plan.md
+++ b/content/tools/ja/alibaba-coding-plan.md
@@ -13,7 +13,7 @@ cons:
   - '汎用 API 自動化より対話型コーディングツール向け'
 affiliate_link: 'https://www.alibabacloud.com/help/ja/model-studio/coding-plan'
 pricing: 'paid'
-price: 'Starter $10 / Pro $50'
+price: 'Pro $50 /month'
 platform:
   - 'Web'
   - 'Desktop'
@@ -33,7 +33,7 @@ Alibaba 側が Qwen Code の公式ガイドを用意しており、CLI やエデ
 
 ### 2. 月額制で回しやすい
 
-Starter / Pro のようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
+Pro プラン ($50/月) のような月額課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です (Liteプランの新規受付は終了しました)。
 
 ### 3. 複数モデルを選べる
 


### PR DESCRIPTION
📝 Content Sync: Refresh alibaba-coding-plan

This PR addresses outdated pricing discovered via content synchronization for the Alibaba Cloud Model Studio Coding Plan. 

The `data/content-sync-state.json` indicated the latest pricing is `$50 /month`, with the note: "Effective March 20, 2026 at 00:00:00 (UTC+8), the Lite plan will no longer accept new subscriptions." 

Therefore, I have:
- Updated the metadata `price` to `Pro $50 /month`.
- Updated the content copy under "Predictable pricing" (and its Japanese equivalent) to highlight the $50/month Pro tier and mention that the Lite plan is discontinued. 
- Ensure that both the English and Japanese documentation parity is maintained.

---
*PR created automatically by Jules for task [7906687637902084959](https://jules.google.com/task/7906687637902084959) started by @yuga-hashimoto*