### PR TITLE
🧭 Trust Builder: Improve schema/metadata validity

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -114,6 +117,22 @@ export function generateProductSchema(tool: Tool) {
       "reviewCount": metadata.rating_breakdown ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0) : 1,
       "bestRating": bestRating,
       "worstRating": "1"
+    };
+
+    schema.review = {
+      "@type": "Review",
+      "reviewRating": {
+        "@type": "Rating",
+        "ratingValue": metadata.rating,
+        "bestRating": bestRating,
+        "worstRating": "1"
+      },
+      "author": {
+        "@type": "Organization",
+        "name": "AI Tool Navigator"
+      },
+      "reviewBody": metadata.description,
+      "datePublished": metadata.last_updated || new Date().toISOString()
     };
   }
 
@@ -155,11 +174,11 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",
-      "url": metadata.affiliate_link,
+      "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "price": "0",
       "priceCurrency": "USD",
       "availability": "https://schema.org/InStock"


### PR DESCRIPTION
Improves the validity of the Schema.org data generated by `generateProductSchema` and `generateToolSchema`.

Previously, the `offers` object with `price: "0"` was included unconditionally (or based on the mere presence of an `affiliate_link`), which would result in deceptive rich snippets displaying $0 prices for paid tools. This PR ensures that the `$0` offer is only included when the tool's pricing model is explicitly 'free' or 'freemium'.

It also adds the missing `Review` object to `generateProductSchema` to correctly attribute reviews to the AI Tool Navigator, matching the behavior of `generateToolSchema`.

---
*PR created automatically by Jules for task [6773793413516755889](https://jules.google.com/task/6773793413516755889) started by @yuga-hashimoto*