### PR TITLE
🧭 Trust Builder: Improve scheme/metadata pricing disclosure

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if ((metadata.pricing === 'free' || metadata.pricing === 'freemium') && metadata.affiliate_link) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR fixes an issue where the `Offer` schema block was hardcoded to `price: "0"` for all products and tools. This caused paid tools to incorrectly show up with `$0` pricing in structured data, which is deceptive and violates trust/SEO quality guidelines.

Changes:
- Modified `generateProductSchema` in `src/lib/schema.ts` to conditionally attach the `offers` property.
- Modified `generateToolSchema` in `src/lib/schema.ts` to check `metadata.pricing` before adding the `$0` offer.
- Offer block is now only added if `metadata.pricing === 'free'` or `'freemium'`.

This change strictly improves structured discoverability and ensures we avoid overclaiming price availability.

---
*PR created automatically by Jules for task [14598968599987063651](https://jules.google.com/task/14598968599987063651) started by @yuga-hashimoto*