### PR TITLE
🧭 Trust Builder: Improve schema/metadata by preventing deceptive $0 prices for paid tools

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
Update `src/lib/schema.ts` functions `generateProductSchema` and `generateToolSchema` to only append the zero-dollar `Offer` schema segment for tools with a `free` or `freemium` pricing model. This addresses an issue where the site was incorrectly generating a `$0` price for all tools (including paid ones), which can lead to deceptive search engine snippets, thereby enhancing editorial trust and search quality.

---
*PR created automatically by Jules for task [6126459431851964627](https://jules.google.com/task/6126459431851964627) started by @yuga-hashimoto*