### PR TITLE
🧭 Trust Builder: Improve structured data pricing accuracy

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === 'free' || metadata.pricing === 'freemium')) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR implements a trust-focused improvement to the site's structured data.

Previously, `generateProductSchema` and `generateToolSchema` hardcoded a `$0` price offer for all tools, regardless of their actual pricing model. This could lead to deceptive rich snippets in search results where paid tools appear to be free, violating search engine guidelines and user trust.

This change conditionally includes the `$0` offer object only when `metadata.pricing` is explicitly set to `free` or `freemium`.

This aligns with the goal of improving transparency, avoiding overclaiming, and enhancing the site's long-term editorial trust.

---
*PR created automatically by Jules for task [17294247634493503722](https://jules.google.com/task/17294247634493503722) started by @yuga-hashimoto*