### PR TITLE
📝 Content Sync: Refresh Alibaba Cloud Model Studio Coding Plan

### DIFF
--- a/content/tools/en/alibaba-coding-plan.md
+++ b/content/tools/en/alibaba-coding-plan.md
@@ -13,7 +13,7 @@ cons:
   - "Primarily designed for interactive coding tools rather than generic automation"
 affiliate_link: "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
 pricing: "paid"
-price: "Starter $10 / Pro $50"
+price: "$50/month (Pro)"
 platform:
   - "Web"
   - "Desktop"
@@ -33,7 +33,7 @@ Alibaba provides an official setup path for Qwen Code, including dedicated CLI a
 
 ### 2. Predictable pricing
 
-The public plan overview lists Starter and Pro tiers, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
+The public plan overview lists a $50/month Pro tier, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
 
 ### 3. Multi-model support
 


### PR DESCRIPTION
Updates the `alibaba-coding-plan` tool page to reflect that the Lite plan ($10/month) is no longer accepting new subscriptions. The updated pricing metadata and description now accurately point to the $50/month Pro plan.

---
*PR created automatically by Jules for task [10319646314538407176](https://jules.google.com/task/10319646314538407176) started by @yuga-hashimoto*