### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getCategoryLandingContent } from "@/lib/category-landing";
 import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
+import { ArrowRight, ExternalLink } from "lucide-react";
 
 export async function generateStaticParams() {
   return Object.keys(CATEGORY_MAPPINGS).map((slug) => ({
@@ -233,9 +234,10 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="group inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link
@@ -347,9 +349,10 @@ export default async function CategoryPage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position="category_compare_table"
-                            className="text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
+                            className="inline-flex items-center justify-center text-xs font-semibold text-green-600 hover:text-green-500 dark:text-green-400"
                           >
                             {copy.visitLabel}
+                            <ExternalLink className="ml-1 h-3 w-3" />
                           </AffiliateLinkButton>
                         </div>
                       </td>

--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -10,6 +10,7 @@ import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
 import { getComparePresetBySlug, parseComparisonSlug } from "@/lib/compare-pages";
 import { getEditorialToolStatus, isReviewPendingToolSlug } from "@/lib/editorial";
 import { Link } from "@/i18n/routing";
+import { ExternalLink } from "lucide-react";
 
 interface PageParams {
   locale: string;
@@ -283,9 +284,10 @@ export default async function CompareTemplatePage({
                             toolSlug={tool.slug}
                             toolName={tool.title}
                             position={`compare_template_${comparisonSlug}`}
-                            className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
+                            className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-1 h-3 w-3" />
                           </AffiliateLinkButton>
                         </div>
                       </td>


### PR DESCRIPTION
Added visual cues (icons) to CTA buttons on category and comparison pages to improve clarity and conversion rates. The internal "Compare this category" CTA now includes a right arrow with hover transition, and the outbound "Visit site" affiliate links include an external link icon, setting appropriate user expectations.

---
*PR created automatically by Jules for task [5437172002196380566](https://jules.google.com/task/5437172002196380566) started by @yuga-hashimoto*