### PR TITLE
🧭 Trust Builder: Improve schema pricing transparency

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === 'free' || metadata.pricing === 'freemium')) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
**Issue**: The current schema generator defaults to setting `"price": "0"` on the Offer object for all tools in `generateProductSchema` and `generateToolSchema`. This leads to misleading and potentially deceptive rich snippets in search engines, incorrectly labeling purely paid software as free.

**Resolution**: Updated `src/lib/schema.ts` to conditionally inject the `Offer` block (specifically the $0 price point) only when a tool's metadata explicitly marks its pricing as `free` or `freemium`. This ensures better structured data hygiene, aligns with editorial transparency standards, and avoids overclaiming search visibility using false low-price signals.

---
*PR created automatically by Jules for task [7705925130829301456](https://jules.google.com/task/7705925130829301456) started by @yuga-hashimoto*