### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior

### DIFF
--- a/src/app/api/leads/exit-intent/route.ts
+++ b/src/app/api/leads/exit-intent/route.ts
@@ -331,9 +331,14 @@ export async function POST(request: NextRequest) {
     try {
       if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
         await appendSubscriber(`lead_${leadId.substring(5)}`);
+        console.log(`[EXIT INTENT LEAD] New subscriber appended to Google Sheets: lead_${leadId.substring(5)}`);
+      } else {
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+        console.log(`[EXIT INTENT LEAD FALLBACK] New lead captured locally: ${leadId}`);
       }
     } catch (sheetsError) {
-      console.error('Failed to append to Google Sheets:', sheetsError);
+      console.warn('Google Sheets append failed, falling back to local logging:', sheetsError);
+      console.log(`[EXIT INTENT LEAD FALLBACK] New lead captured locally: ${leadId}`);
     }
 
     // Log the submission

--- a/src/app/api/partner-inquiry/route.ts
+++ b/src/app/api/partner-inquiry/route.ts
@@ -48,26 +48,26 @@ export async function POST(request: NextRequest) {
     });
 
     try {
-      await appendPartnerInquiry({
-        inquiryType: record.inquiryType,
-        companyName: record.companyName,
-        contactName: record.contactName,
-        email: record.email,
-        websiteUrl: record.websiteUrl,
-        packageInterest: record.packageInterest,
-        monthlyBudget: record.monthlyBudget,
-        message: record.message,
-        locale: record.locale,
-      });
-      console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
-    } catch (sheetError) {
-      const errorMsg = sheetError instanceof Error ? sheetError.message : String(sheetError);
-      if (errorMsg.includes('not configured')) {
-        console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
+      if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+        await appendPartnerInquiry({
+          inquiryType: record.inquiryType,
+          companyName: record.companyName,
+          contactName: record.contactName,
+          email: record.email,
+          websiteUrl: record.websiteUrl,
+          packageInterest: record.packageInterest,
+          monthlyBudget: record.monthlyBudget,
+          message: record.message,
+          locale: record.locale,
+        });
+        console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
       } else {
-        console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
+        console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
         console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
       }
+    } catch (sheetError) {
+      console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
+      console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
     }
 
     return NextResponse.json({

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -76,10 +76,16 @@ export async function POST(request: NextRequest) {
 
     try {
       try {
-        await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
-        console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+          await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
+          console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        } else {
+          console.warn('GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.');
+          console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
+          console.log('Submission data:', { name, url, description, category, pricing_model, price });
+        }
       } catch (sheetError) {
-        console.warn('Google Sheets append failed or not configured, falling back to local logging:', sheetError);
+        console.warn('Google Sheets append failed, falling back to local logging:', sheetError);
         console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
         console.log('Submission data:', { name, url, description, category, pricing_model, price });
       }


### PR DESCRIPTION
Updated `api/submit/route.ts`, `api/partner-inquiry/route.ts`, and `api/leads/exit-intent/route.ts` to explicitly verify if `process.env.GOOGLE_SERVICE_ACCOUNT_JSON` is configured prior to invoking Google Sheets append operations. This ensures predictable failure behavior, cleaner fallback logging patterns, and prevents unhandled API errors when the integration is locally or cleanly deployed.

---
*PR created automatically by Jules for task [2269605210352700346](https://jules.google.com/task/2269605210352700346) started by @yuga-hashimoto*