### PR TITLE
🧭 Trust Builder: Improve schema/metadata

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -96,15 +96,18 @@ export function generateProductSchema(tool: Tool) {
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
     "mpn": metadata.slug,
-    "offers": {
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -156,18 +159,20 @@ export function generateToolSchema(tool: Tool) {
   }
 
   if (metadata.affiliate_link) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const offer: any = {
-      "@type": "Offer",
-      "url": metadata.affiliate_link,
-      "price": "0",
-      "priceCurrency": "USD",
-      "availability": "https://schema.org/InStock"
-    };
-    if (metadata.discount) {
-      offer.description = metadata.discount;
+    if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const offer: any = {
+        "@type": "Offer",
+        "url": metadata.affiliate_link,
+        "price": "0",
+        "priceCurrency": "USD",
+        "availability": "https://schema.org/InStock"
+      };
+      if (metadata.discount) {
+        offer.description = metadata.discount;
+      }
+      schema.offers = offer;
     }
-    schema.offers = offer;
   }
 
   if (metadata.rating) {


### PR DESCRIPTION
This PR fixes a critical trust and SEO issue where the structured data (JSON-LD) for products and tools hardcoded a price of "$0" in the `Offer` object for *all* tools, even paid ones. 

To prevent deceptive rich snippets and potential search engine penalties for "overclaiming", the schema generators (`generateProductSchema` and `generateToolSchema`) have been updated to conditionally include the `$0` `Offer` only when the tool's `metadata.pricing` explicitly indicates it is "free" or "freemium".

This change improves editorial trust and search discoverability by ensuring our structured data accurately reflects reality.

---
*PR created automatically by Jules for task [11077320108578609535](https://jules.google.com/task/11077320108578609535) started by @yuga-hashimoto*