### PR TITLE
📝 Content Sync: Refresh alibaba-coding-plan

### DIFF
--- a/content/tools/en/alibaba-coding-plan.md
+++ b/content/tools/en/alibaba-coding-plan.md
@@ -13,11 +13,11 @@ cons:
   - "Primarily designed for interactive coding tools rather than generic automation"
 affiliate_link: "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
 pricing: "paid"
-price: "Starter $10 / Pro $50"
+price: "$50 /month"
 platform:
   - "Web"
   - "Desktop"
-last_updated: "2026-03-07"
+last_updated: "2026-04-24"
 verified: true
 ---
 
@@ -33,7 +33,7 @@ Alibaba provides an official setup path for Qwen Code, including dedicated CLI a
 
 ### 2. Predictable pricing
 
-The public plan overview lists Starter and Pro tiers, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
+The public plan overview lists the Pro tier, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
 
 ### 3. Multi-model support
 

--- a/content/tools/ja/alibaba-coding-plan.md
+++ b/content/tools/ja/alibaba-coding-plan.md
@@ -1,23 +1,23 @@
 ---
-title: 'Alibaba Cloud Model Studio Coding Plan'
-slug: 'alibaba-coding-plan'
-category: 'Coding Assistant'
-description: 'Alibaba Cloud の定額型 Coding Plan。Qwen Code、Claude Code、Cline、Cursor などの開発フローで使いやすい。'
+title: "Alibaba Cloud Model Studio Coding Plan"
+slug: "alibaba-coding-plan"
+category: "Coding Assistant"
+description: "Alibaba Cloud の定額型 Coding Plan。Qwen Code、Claude Code、Cline、Cursor などの開発フローで使いやすい。"
 rating: 4.7
 pros:
-  - 'Qwen Code の公式導線が強く CLI と拡張機能の両方が揃う'
-  - 'Starter / Pro の月額制で予算管理しやすい'
-  - 'Qwen 系だけでなく複数モデルを使い分けやすい'
+  - "Qwen Code の公式導線が強く CLI と拡張機能の両方が揃う"
+  - "Proの月額制で予算管理しやすい"
+  - "Qwen 系だけでなく複数モデルを使い分けやすい"
 cons:
-  - '通常の Model Studio API とはキーと Base URL が別'
-  - '汎用 API 自動化より対話型コーディングツール向け'
-affiliate_link: 'https://www.alibabacloud.com/help/ja/model-studio/coding-plan'
-pricing: 'paid'
-price: 'Starter $10 / Pro $50'
+  - "通常の Model Studio API とはキーと Base URL が別"
+  - "汎用 API 自動化より対話型コーディングツール向け"
+affiliate_link: "https://www.alibabacloud.com/help/ja/model-studio/coding-plan"
+pricing: "paid"
+price: "$50 /月"
 platform:
-  - 'Web'
-  - 'Desktop'
-last_updated: '2026-03-07'
+  - "Web"
+  - "Desktop"
+last_updated: "2026-04-24"
 verified: true
 ---
 
@@ -33,7 +33,7 @@ Alibaba 側が Qwen Code の公式ガイドを用意しており、CLI やエデ
 
 ### 2. 月額制で回しやすい
 
-Starter / Pro のようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
+Proのようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
 
 ### 3. 複数モデルを選べる
 


### PR DESCRIPTION
Updated the Alibaba Cloud Model Studio Coding Plan content based on the latest content sync data.
- Changed pricing from "Starter $10 / Pro $50" to "$50 /month" in English and "$50 /月" in Japanese.
- Removed references to the "Starter" plan from both languages as it is no longer accepting new subscriptions.
- Updated `last_updated` date to today.

---
*PR created automatically by Jules for task [94707611430738360](https://jules.google.com/task/94707611430738360) started by @yuga-hashimoto*