### PR TITLE
🧭 Trust Builder: Improve schema conditional offers

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === 'free' || metadata.pricing === 'freemium')) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR modifies the `generateProductSchema` and `generateToolSchema` functions in `src/lib/schema.ts` so that they only output an `Offer` object (with a hardcoded `$0` price) if the tool's `metadata.pricing` property is strictly `'free'` or `'freemium'`.

This addresses a critical issue where paid tools were inadvertently generating an `Offer` schema declaring they cost $0, which could lead to search engines displaying misleading rich snippets and subsequent manual action penalties against the site for deceptive data.

---
*PR created automatically by Jules for task [7040160071220500965](https://jules.google.com/task/7040160071220500965) started by @yuga-hashimoto*