### PR TITLE
📝 Content Sync: Refresh Alibaba Cloud Model Studio Coding Plan

### DIFF
--- a/content/tools/en/alibaba-coding-plan.md
+++ b/content/tools/en/alibaba-coding-plan.md
@@ -13,7 +13,7 @@ cons:
   - "Primarily designed for interactive coding tools rather than generic automation"
 affiliate_link: "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
 pricing: "paid"
-price: "Starter $10 / Pro $50"
+price: "Pro $50/month"
 platform:
   - "Web"
   - "Desktop"
@@ -33,7 +33,7 @@ Alibaba provides an official setup path for Qwen Code, including dedicated CLI a
 
 ### 2. Predictable pricing
 
-The public plan overview lists Starter and Pro tiers, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage.
+The public plan overview lists a $50/month Pro tier, which is easier to budget for than unrestricted API billing when you are testing heavy daily coding usage. (Note: The Lite tier was discontinued for new subscriptions in March 2026).
 
 ### 3. Multi-model support
 

--- a/content/tools/ja/alibaba-coding-plan.md
+++ b/content/tools/ja/alibaba-coding-plan.md
@@ -1,23 +1,23 @@
 ---
-title: 'Alibaba Cloud Model Studio Coding Plan'
-slug: 'alibaba-coding-plan'
-category: 'Coding Assistant'
-description: 'Alibaba Cloud の定額型 Coding Plan。Qwen Code、Claude Code、Cline、Cursor などの開発フローで使いやすい。'
+title: "Alibaba Cloud Model Studio Coding Plan"
+slug: "alibaba-coding-plan"
+category: "Coding Assistant"
+description: "Alibaba Cloud の定額型 Coding Plan。Qwen Code、Claude Code、Cline、Cursor などの開発フローで使いやすい。"
 rating: 4.7
 pros:
-  - 'Qwen Code の公式導線が強く CLI と拡張機能の両方が揃う'
-  - 'Starter / Pro の月額制で予算管理しやすい'
-  - 'Qwen 系だけでなく複数モデルを使い分けやすい'
+  - "Qwen Code の公式導線が強く CLI と拡張機能の両方が揃う"
+  - "Pro の月額制で予算管理しやすい"
+  - "Qwen 系だけでなく複数モデルを使い分けやすい"
 cons:
-  - '通常の Model Studio API とはキーと Base URL が別'
-  - '汎用 API 自動化より対話型コーディングツール向け'
-affiliate_link: 'https://www.alibabacloud.com/help/ja/model-studio/coding-plan'
-pricing: 'paid'
-price: 'Starter $10 / Pro $50'
+  - "通常の Model Studio API とはキーと Base URL が別"
+  - "汎用 API 自動化より対話型コーディングツール向け"
+affiliate_link: "https://www.alibabacloud.com/help/ja/model-studio/coding-plan"
+pricing: "paid"
+price: "Pro $50/月"
 platform:
-  - 'Web'
-  - 'Desktop'
-last_updated: '2026-03-07'
+  - "Web"
+  - "Desktop"
+last_updated: "2026-03-07"
 verified: true
 ---
 
@@ -33,7 +33,7 @@ Alibaba 側が Qwen Code の公式ガイドを用意しており、CLI やエデ
 
 ### 2. 月額制で回しやすい
 
-Starter / Pro のようなプラン課金なので、従量課金の API よりコストを読みやすく、検証や日常開発へ載せやすい設計です。
+Proプラン（$50/月）による固定課金なので、従量課金のAPIよりコストを読みやすく、検証や日常開発へ載せやすい設計です。（※Starter/Liteプランは2026年3月に新規受付を終了しました）
 
 ### 3. 複数モデルを選べる
 


### PR DESCRIPTION
This PR updates the pricing information for the "Alibaba Cloud Model Studio Coding Plan" based on the latest content sync data. Specifically, it reflects the discontinuation of the Lite/Starter tier for new subscriptions and standardizes the pricing to the $50/month Pro tier in both the English and Japanese localized tool pages.

---
*PR created automatically by Jules for task [7188050628167907642](https://jules.google.com/task/7188050628167907642) started by @yuga-hashimoto*