### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getCategoryLandingContent } from "@/lib/category-landing";
 import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
+import { ArrowRight } from "lucide-react";
 
 export async function generateStaticParams() {
   return Object.keys(CATEGORY_MAPPINGS).map((slug) => ({
@@ -233,9 +234,10 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="group inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkDirective from "remark-directive";
 import { remarkYoutube } from "@/lib/remark-youtube";
-import { ExternalLink, BadgeCheck, Calendar } from "lucide-react";
+import { ExternalLink, BadgeCheck, Calendar, ArrowRight } from "lucide-react";
 import { Metadata } from "next";
 import { Rating } from "@/components/Rating";
 import { ArticleCard } from "@/components/ArticleCard";
@@ -395,9 +395,10 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                   {compareHref && (
                     <Link
                       href={compareHref}
-                      className="inline-flex items-center rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                      className="group inline-flex items-center rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                     >
                       {copy.compareCategory}
+                      <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                     </Link>
                   )}
                   {categorySlug && (

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
This PR improves the internal linking and user engagement for comparison pages by adding a distinct micro-interaction to the "Compare this category" CTA button on both the Category pages and Tool pages.

It introduces the `ArrowRight` icon from `lucide-react` to the CTA button, and leverages Tailwind's `group` and `group-hover:translate-x-1` classes. This creates a subtle animation where the arrow slides right when hovered, drawing the user's attention and encouraging them to click and explore the comparison views.

---
*PR created automatically by Jules for task [18237992364125867111](https://jules.google.com/task/18237992364125867111) started by @yuga-hashimoto*