### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { ArrowRight } from "lucide-react";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -23,7 +24,11 @@ export async function generateStaticParams() {
   }));
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
   const { slug, locale } = await params;
 
   if (!Object.keys(CATEGORY_MAPPINGS).includes(slug)) {
@@ -77,25 +82,26 @@ function formatUpdatedDate(value: string | undefined, locale: string): string {
 function formatPricingLabel(
   locale: string,
   price: string | undefined,
-  pricing: "free" | "freemium" | "paid" | "contact" | undefined
+  pricing: "free" | "freemium" | "paid" | "contact" | undefined,
 ): string {
   if (price) {
     return price;
   }
 
-  const labels = locale === "ja"
-    ? {
-        free: "無料",
-        freemium: "フリーミアム",
-        paid: "有料",
-        contact: "要問い合わせ",
-      }
-    : {
-        free: "Free",
-        freemium: "Freemium",
-        paid: "Paid",
-        contact: "Contact sales",
-      };
+  const labels =
+    locale === "ja"
+      ? {
+          free: "無料",
+          freemium: "フリーミアム",
+          paid: "有料",
+          contact: "要問い合わせ",
+        }
+      : {
+          free: "Free",
+          freemium: "Freemium",
+          paid: "Paid",
+          contact: "Contact sales",
+        };
 
   return pricing ? labels[pricing] : locale === "ja" ? "未掲載" : "Not listed";
 }
@@ -115,18 +121,24 @@ export default async function CategoryPage({
   const t = await getTranslations("CategoryPage");
   const tBreadcrumbs = await getTranslations("Breadcrumbs");
 
-  const targetCategories = CATEGORY_MAPPINGS[slug as keyof typeof CATEGORY_MAPPINGS];
+  const targetCategories =
+    CATEGORY_MAPPINGS[slug as keyof typeof CATEGORY_MAPPINGS];
   const tools = await getAllTools(locale);
   const filteredTools = filterToolList(
-    tools.filter((tool) => targetCategories.includes(tool.category))
+    tools.filter((tool) => targetCategories.includes(tool.category)),
   ).sort(sortToolsForEditorialLists);
 
   const title = t(`${slug}_title` as never);
   const description = t(`${slug}_description` as never);
-  const landing = getCategoryLandingContent(slug, isJapanese ? "ja" : "en", title);
+  const landing = getCategoryLandingContent(
+    slug,
+    isJapanese ? "ja" : "en",
+    title,
+  );
   const featuredTools = filteredTools.slice(0, 5);
   const compareSlugs = featuredTools.slice(0, 3).map((tool) => tool.slug);
-  const compareHref = compareSlugs.length >= 2 ? getComparisonHref(compareSlugs) : null;
+  const compareHref =
+    compareSlugs.length >= 2 ? getComparisonHref(compareSlugs) : null;
   const verifiedCount = filteredTools.filter((tool) => tool.verified).length;
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -233,16 +245,18 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="group inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link
                   href="/tools"
-                  className="inline-flex items-center rounded-full border border-zinc-300 px-6 py-3 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
+                  className="group inline-flex items-center rounded-full border border-zinc-300 px-6 py-3 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
                 >
                   {copy.browseAllCta}
+                  <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Link>
               </div>
             </div>
@@ -253,7 +267,10 @@ export default async function CategoryPage({
               </h2>
               <ul className="mt-5 space-y-4">
                 {landing.selectionPoints.map((point) => (
-                  <li key={point} className="flex gap-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                  <li
+                    key={point}
+                    className="flex gap-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400"
+                  >
                     <span className="mt-2 h-2.5 w-2.5 flex-none rounded-full bg-blue-600 dark:bg-blue-400" />
                     <span>{point}</span>
                   </li>
@@ -313,10 +330,16 @@ export default async function CategoryPage({
                   {featuredTools.map((tool) => (
                     <tr key={tool.slug} className="align-top">
                       <td className="px-6 py-4">
-                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">{tool.title}</div>
-                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{tool.description}</div>
+                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">
+                          {tool.title}
+                        </div>
+                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                          {tool.description}
+                        </div>
                       </td>
-                      <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">{tool.rating ?? "-"}</td>
+                      <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">
+                        {tool.rating ?? "-"}
+                      </td>
                       <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">
                         {formatPricingLabel(locale, tool.price, tool.pricing)}
                       </td>
@@ -328,7 +351,9 @@ export default async function CategoryPage({
                               : "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/30"
                           }`}
                         >
-                          {tool.verified ? copy.statusVerified : copy.statusPending}
+                          {tool.verified
+                            ? copy.statusVerified
+                            : copy.statusPending}
                         </span>
                       </td>
                       <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -9,6 +9,7 @@ import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
+import { ArrowRight } from "lucide-react";
 
 export async function generateMetadata({
   params,
@@ -19,7 +20,9 @@ export async function generateMetadata({
   const isJapanese = locale === "ja";
 
   return {
-    title: isJapanese ? "AIツール比較ハブ | AI Tool Navigator" : "Compare AI Tools | AI Tool Navigator",
+    title: isJapanese
+      ? "AIツール比較ハブ | AI Tool Navigator"
+      : "Compare AI Tools | AI Tool Navigator",
     description: isJapanese
       ? "主要AIツールを横並びで比較。価格、検証状況、長所短所を確認し、最適なAIソリューションを見つけましょう。"
       : "Compare leading AI tools side-by-side. Evaluate features, pricing, review status, and pros/cons to find the best AI solution for your workflow.",
@@ -36,7 +39,9 @@ export default async function ComparePage({
 }) {
   const { locale } = await params;
   const isJapanese = locale === "ja";
-  const tools = filterToolList(await getAllTools(locale)).sort(sortToolsForEditorialLists);
+  const tools = filterToolList(await getAllTools(locale)).sort(
+    sortToolsForEditorialLists,
+  );
   const tBreadcrumbs = await getTranslations("Breadcrumbs");
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -123,12 +128,17 @@ export default async function ComparePage({
               <Link
                 key={preset.title}
                 href={preset.href}
-                className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                className="group rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
               >
-                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">{preset.title}</h3>
-                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">{preset.description}</p>
-                <div className="mt-5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">
+                  {preset.title}
+                </h3>
+                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                  {preset.description}
+                </p>
+                <div className="mt-5 inline-flex items-center text-sm font-semibold text-blue-600 dark:text-blue-400">
                   {copy.presetCta}
+                  <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </div>
               </Link>
             ))}


### PR DESCRIPTION
This PR adds `ArrowRight` icons with an animated `group-hover:translate-x-1` translation to the comparison-related internal Call-to-Action (CTA) buttons.

Specifically:
- In `category/[slug]/page.tsx`, it updates the `compareCta` ("Compare this category") and `browseAllCta` buttons.
- In `compare/page.tsx`, it updates the preset comparison `presetCta` buttons on the Quick-start comparison presets cards.

This change subtly improves visual clarity, interactivity, and affordance, helping to drive higher click-through rates into detailed comparison flows without resorting to spammy tactics.

---
*PR created automatically by Jules for task [10693271014608816308](https://jules.google.com/task/10693271014608816308) started by @yuga-hashimoto*