### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { ArrowRight } from "lucide-react";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -23,7 +24,11 @@ export async function generateStaticParams() {
   }));
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
   const { slug, locale } = await params;
 
   if (!Object.keys(CATEGORY_MAPPINGS).includes(slug)) {
@@ -77,25 +82,26 @@ function formatUpdatedDate(value: string | undefined, locale: string): string {
 function formatPricingLabel(
   locale: string,
   price: string | undefined,
-  pricing: "free" | "freemium" | "paid" | "contact" | undefined
+  pricing: "free" | "freemium" | "paid" | "contact" | undefined,
 ): string {
   if (price) {
     return price;
   }
 
-  const labels = locale === "ja"
-    ? {
-        free: "無料",
-        freemium: "フリーミアム",
-        paid: "有料",
-        contact: "要問い合わせ",
-      }
-    : {
-        free: "Free",
-        freemium: "Freemium",
-        paid: "Paid",
-        contact: "Contact sales",
-      };
+  const labels =
+    locale === "ja"
+      ? {
+          free: "無料",
+          freemium: "フリーミアム",
+          paid: "有料",
+          contact: "要問い合わせ",
+        }
+      : {
+          free: "Free",
+          freemium: "Freemium",
+          paid: "Paid",
+          contact: "Contact sales",
+        };
 
   return pricing ? labels[pricing] : locale === "ja" ? "未掲載" : "Not listed";
 }
@@ -115,18 +121,24 @@ export default async function CategoryPage({
   const t = await getTranslations("CategoryPage");
   const tBreadcrumbs = await getTranslations("Breadcrumbs");
 
-  const targetCategories = CATEGORY_MAPPINGS[slug as keyof typeof CATEGORY_MAPPINGS];
+  const targetCategories =
+    CATEGORY_MAPPINGS[slug as keyof typeof CATEGORY_MAPPINGS];
   const tools = await getAllTools(locale);
   const filteredTools = filterToolList(
-    tools.filter((tool) => targetCategories.includes(tool.category))
+    tools.filter((tool) => targetCategories.includes(tool.category)),
   ).sort(sortToolsForEditorialLists);
 
   const title = t(`${slug}_title` as never);
   const description = t(`${slug}_description` as never);
-  const landing = getCategoryLandingContent(slug, isJapanese ? "ja" : "en", title);
+  const landing = getCategoryLandingContent(
+    slug,
+    isJapanese ? "ja" : "en",
+    title,
+  );
   const featuredTools = filteredTools.slice(0, 5);
   const compareSlugs = featuredTools.slice(0, 3).map((tool) => tool.slug);
-  const compareHref = compareSlugs.length >= 2 ? getComparisonHref(compareSlugs) : null;
+  const compareHref =
+    compareSlugs.length >= 2 ? getComparisonHref(compareSlugs) : null;
   const verifiedCount = filteredTools.filter((tool) => tool.verified).length;
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -233,16 +245,18 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="group inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link
                   href="/tools"
-                  className="inline-flex items-center rounded-full border border-zinc-300 px-6 py-3 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
+                  className="group inline-flex items-center rounded-full border border-zinc-300 px-6 py-3 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
                 >
                   {copy.browseAllCta}
+                  <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Link>
               </div>
             </div>
@@ -253,7 +267,10 @@ export default async function CategoryPage({
               </h2>
               <ul className="mt-5 space-y-4">
                 {landing.selectionPoints.map((point) => (
-                  <li key={point} className="flex gap-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                  <li
+                    key={point}
+                    className="flex gap-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400"
+                  >
                     <span className="mt-2 h-2.5 w-2.5 flex-none rounded-full bg-blue-600 dark:bg-blue-400" />
                     <span>{point}</span>
                   </li>
@@ -313,10 +330,16 @@ export default async function CategoryPage({
                   {featuredTools.map((tool) => (
                     <tr key={tool.slug} className="align-top">
                       <td className="px-6 py-4">
-                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">{tool.title}</div>
-                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{tool.description}</div>
+                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">
+                          {tool.title}
+                        </div>
+                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                          {tool.description}
+                        </div>
                       </td>
-                      <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">{tool.rating ?? "-"}</td>
+                      <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">
+                        {tool.rating ?? "-"}
+                      </td>
                       <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">
                         {formatPricingLabel(locale, tool.price, tool.pricing)}
                       </td>
@@ -328,7 +351,9 @@ export default async function CategoryPage({
                               : "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/30"
                           }`}
                         >
-                          {tool.verified ? copy.statusVerified : copy.statusPending}
+                          {tool.verified
+                            ? copy.statusVerified
+                            : copy.statusPending}
                         </span>
                       </td>
                       <td className="px-6 py-4 text-sm text-zinc-700 dark:text-zinc-300">

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -5,12 +5,16 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkDirective from "remark-directive";
 import { remarkYoutube } from "@/lib/remark-youtube";
-import { ExternalLink, BadgeCheck, Calendar } from "lucide-react";
+import { ExternalLink, BadgeCheck, Calendar, ArrowRight } from "lucide-react";
 import { Metadata } from "next";
 import { Rating } from "@/components/Rating";
 import { ArticleCard } from "@/components/ArticleCard";
 import { getTranslations } from "next-intl/server";
-import { generateProductSchema, generateToolSchema, generateBreadcrumbSchema } from "@/lib/schema";
+import {
+  generateProductSchema,
+  generateToolSchema,
+  generateBreadcrumbSchema,
+} from "@/lib/schema";
 import { ProsConsSection } from "@/components/ProsConsSection";
 import { RatingBreakdown } from "@/components/RatingBreakdown";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
@@ -43,9 +47,11 @@ export async function generateStaticParams() {
   return slugs;
 }
 
-export async function generateMetadata(
-  { params }: { params: Promise<{ slug: string; locale: string }> }
-): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}): Promise<Metadata> {
   const { slug, locale } = await params;
   const tool = await getToolBySlug(slug, locale);
 
@@ -88,30 +94,39 @@ export async function generateMetadata(
 function formatPricingLabel(
   locale: string,
   price: string | undefined,
-  pricing: "free" | "freemium" | "paid" | "contact" | undefined
+  pricing: "free" | "freemium" | "paid" | "contact" | undefined,
 ): string {
   if (price) {
     return price;
   }
 
-  const labels = locale === "ja"
-    ? {
-        free: "\u7121\u6599",
-        freemium: "\u30D5\u30EA\u30FC\u30DF\u30A2\u30E0",
-        paid: "\u6709\u6599",
-        contact: "\u8981\u554F\u3044\u5408\u308F\u305B",
-      }
-    : {
-        free: "Free",
-        freemium: "Freemium",
-        paid: "Paid",
-        contact: "Contact sales",
-      };
+  const labels =
+    locale === "ja"
+      ? {
+          free: "\u7121\u6599",
+          freemium: "\u30D5\u30EA\u30FC\u30DF\u30A2\u30E0",
+          paid: "\u6709\u6599",
+          contact: "\u8981\u554F\u3044\u5408\u308F\u305B",
+        }
+      : {
+          free: "Free",
+          freemium: "Freemium",
+          paid: "Paid",
+          contact: "Contact sales",
+        };
 
-  return pricing ? labels[pricing] : locale === "ja" ? "\u672A\u63B2\u8F09" : "Not listed";
+  return pricing
+    ? labels[pricing]
+    : locale === "ja"
+      ? "\u672A\u63B2\u8F09"
+      : "Not listed";
 }
 
-export default async function ToolPage({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+export default async function ToolPage({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
   const { slug, locale } = await params;
   const isJapanese = locale === "ja";
   const tool = await getToolBySlug(slug, locale);
@@ -125,7 +140,9 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
 
   const { metadata, content } = tool;
   const { verified, last_updated } = metadata;
-  const relatedPosts = filterPostList(await getRelatedPosts(metadata, 3, locale)).slice(0, 3);
+  const relatedPosts = filterPostList(
+    await getRelatedPosts(metadata, 3, locale),
+  ).slice(0, 3);
   const toolSchema = generateToolSchema(tool);
   const productSchema = generateProductSchema(tool);
   const url = `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}/tools/${slug}`;
@@ -133,13 +150,19 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
   const categorySlug = getCategorySlug(metadata.category);
   const allTools = filterToolList(await getAllTools(locale));
   const compareCandidates = allTools
-    .filter((candidate) => candidate.category === metadata.category && candidate.slug !== slug)
+    .filter(
+      (candidate) =>
+        candidate.category === metadata.category && candidate.slug !== slug,
+    )
     .sort(sortToolsForEditorialLists)
     .slice(0, 3);
 
   const compareHref =
     !isReviewPendingToolSlug(slug) && compareCandidates.length >= 2
-      ? getComparisonHref([slug, ...compareCandidates.map((candidate) => candidate.slug)])
+      ? getComparisonHref([
+          slug,
+          ...compareCandidates.map((candidate) => candidate.slug),
+        ])
       : null;
   const syncSummary = getContentSyncSummary(slug);
 
@@ -148,13 +171,18 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
   ];
 
   if (categorySlug) {
-    breadcrumbItems.push({ label: tBreadcrumbs(categorySlug as never), href: `/category/${categorySlug}` });
+    breadcrumbItems.push({
+      label: tBreadcrumbs(categorySlug as never),
+      href: `/category/${categorySlug}`,
+    });
   }
 
   breadcrumbItems.push({ label: metadata.title });
 
   const components = {
-    "youtube-embed": (props: ComponentProps<typeof YouTubeEmbed>) => <YouTubeEmbed {...props} />,
+    "youtube-embed": (props: ComponentProps<typeof YouTubeEmbed>) => (
+      <YouTubeEmbed {...props} />
+    ),
     img: ({ src, alt }: { src?: string; alt?: string }) => (
       <MarkdownImage src={src} alt={alt} />
     ),
@@ -165,17 +193,24 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
   const copy = isJapanese
     ? {
         reviewTitle: "\u7DE8\u96C6\u30EC\u30D3\u30E5\u30FC\u60C5\u5831",
-        reviewedHeadline: "\u3053\u306E\u63B2\u8F09\u306F\u78BA\u8A8D\u6E08\u307F\u3067\u3059",
-        reviewedBody: "\u4E3B\u8981\u306A\u6A5F\u80FD\u3001\u30EA\u30F3\u30AF\u3001\u66F4\u65B0\u65E5\u3092\u78BA\u8A8D\u3057\u305F\u3046\u3048\u3067\u3001\u6BD4\u8F03\u30CF\u30D6\u3084\u30AB\u30C6\u30B4\u30EALP\u304B\u3089\u6848\u5185\u3057\u3066\u3044\u307E\u3059\u3002",
-        pendingHeadline: "\u3053\u306E\u63B2\u8F09\u306F\u78BA\u8A8D\u5F85\u3061\u3067\u3059",
-        pendingBody: "\u516C\u958B\u60C5\u5831\u3092\u5143\u306B\u63B2\u8F09\u3057\u3066\u3044\u307E\u3059\u3002\u4FA1\u683C\u3084\u6A5F\u80FD\u306F\u516C\u5F0F\u30B5\u30A4\u30C8\u3067\u5FC5\u305A\u518D\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
-        archivedHeadline: "\u3053\u306E\u63B2\u8F09\u306F\u7D22\u5F15\u5BFE\u8C61\u5916\u3067\u3059",
-        archivedBody: "\u540D\u79F0\u3084\u60C5\u5831\u306E\u4FE1\u983C\u6027\u306B\u78BA\u8A8D\u8AB2\u984C\u304C\u3042\u308B\u305F\u3081\u3001\u4E3B\u8981\u5C0E\u7DDA\u3068\u30A4\u30F3\u30C7\u30C3\u30AF\u30B9\u304B\u3089\u306F\u5916\u3057\u3066\u3044\u307E\u3059\u3002\u53C2\u8003\u95B2\u89A7\u306E\u307F\u3092\u60F3\u5B9A\u3057\u3066\u3044\u307E\u3059\u3002",
+        reviewedHeadline:
+          "\u3053\u306E\u63B2\u8F09\u306F\u78BA\u8A8D\u6E08\u307F\u3067\u3059",
+        reviewedBody:
+          "\u4E3B\u8981\u306A\u6A5F\u80FD\u3001\u30EA\u30F3\u30AF\u3001\u66F4\u65B0\u65E5\u3092\u78BA\u8A8D\u3057\u305F\u3046\u3048\u3067\u3001\u6BD4\u8F03\u30CF\u30D6\u3084\u30AB\u30C6\u30B4\u30EALP\u304B\u3089\u6848\u5185\u3057\u3066\u3044\u307E\u3059\u3002",
+        pendingHeadline:
+          "\u3053\u306E\u63B2\u8F09\u306F\u78BA\u8A8D\u5F85\u3061\u3067\u3059",
+        pendingBody:
+          "\u516C\u958B\u60C5\u5831\u3092\u5143\u306B\u63B2\u8F09\u3057\u3066\u3044\u307E\u3059\u3002\u4FA1\u683C\u3084\u6A5F\u80FD\u306F\u516C\u5F0F\u30B5\u30A4\u30C8\u3067\u5FC5\u305A\u518D\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002",
+        archivedHeadline:
+          "\u3053\u306E\u63B2\u8F09\u306F\u7D22\u5F15\u5BFE\u8C61\u5916\u3067\u3059",
+        archivedBody:
+          "\u540D\u79F0\u3084\u60C5\u5831\u306E\u4FE1\u983C\u6027\u306B\u78BA\u8A8D\u8AB2\u984C\u304C\u3042\u308B\u305F\u3081\u3001\u4E3B\u8981\u5C0E\u7DDA\u3068\u30A4\u30F3\u30C7\u30C3\u30AF\u30B9\u304B\u3089\u306F\u5916\u3057\u3066\u3044\u307E\u3059\u3002\u53C2\u8003\u95B2\u89A7\u306E\u307F\u3092\u60F3\u5B9A\u3057\u3066\u3044\u307E\u3059\u3002",
         pricing: "\u6599\u91D1",
         platform: "\u5BFE\u5FDC\u74B0\u5883",
         status: "\u30B9\u30C6\u30FC\u30BF\u30B9",
         unknown: "\u672A\u63B2\u8F09",
-        compareCategory: "\u3053\u306E\u30AB\u30C6\u30B4\u30EA\u3092\u6BD4\u8F03",
+        compareCategory:
+          "\u3053\u306E\u30AB\u30C6\u30B4\u30EA\u3092\u6BD4\u8F03",
         browseCategory: "\u30AB\u30C6\u30B4\u30EALP\u3092\u898B\u308B",
         verifiedLabel: "\u78BA\u8A8D\u6E08\u307F",
         pendingLabel: "\u8981\u78BA\u8A8D",
@@ -185,16 +220,21 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
         syncTitle: "\u516C\u5F0F\u60C5\u5831\u306E\u76E3\u8996\u72B6\u6CC1",
         syncLastChecked: "\u6700\u7D42\u78BA\u8A8D",
         syncLastChanged: "\u5DEE\u5206\u691C\u77E5",
-        syncNoData: "\u307E\u3060\u81EA\u52D5\u76E3\u8996\u306E\u30B9\u30CA\u30C3\u30D7\u30B7\u30E7\u30C3\u30C8\u306F\u3042\u308A\u307E\u305B\u3093\u3002",
+        syncNoData:
+          "\u307E\u3060\u81EA\u52D5\u76E3\u8996\u306E\u30B9\u30CA\u30C3\u30D7\u30B7\u30E7\u30C3\u30C8\u306F\u3042\u308A\u307E\u305B\u3093\u3002",
       }
     : {
         reviewTitle: "Editorial review",
         reviewedHeadline: "This listing has been reviewed",
-        reviewedBody: "We surface this tool in our category hubs after checking core features, links, and update signals.",
+        reviewedBody:
+          "We surface this tool in our category hubs after checking core features, links, and update signals.",
         pendingHeadline: "This listing still needs review",
-        pendingBody: "Use this page as a starting point, but confirm pricing and feature details on the official site before acting on them.",
-        archivedHeadline: "This listing is excluded from indexed recommendations",
-        archivedBody: "We keep the page available for reference, but it is removed from primary entry points until editorial review is complete.",
+        pendingBody:
+          "Use this page as a starting point, but confirm pricing and feature details on the official site before acting on them.",
+        archivedHeadline:
+          "This listing is excluded from indexed recommendations",
+        archivedBody:
+          "We keep the page available for reference, but it is removed from primary entry points until editorial review is complete.",
         pricing: "Pricing",
         platform: "Platforms",
         status: "Status",
@@ -216,25 +256,26 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
     editorialStatus === "reviewed"
       ? copy.verifiedLabel
       : editorialStatus === "pending_review"
-      ? copy.pendingLabel
-      : copy.archivedLabel;
+        ? copy.pendingLabel
+        : copy.archivedLabel;
 
   const statusHeadline =
     editorialStatus === "reviewed"
       ? copy.reviewedHeadline
       : editorialStatus === "pending_review"
-      ? copy.pendingHeadline
-      : copy.archivedHeadline;
+        ? copy.pendingHeadline
+        : copy.archivedHeadline;
 
   const statusBody =
     editorialStatus === "reviewed"
       ? copy.reviewedBody
       : editorialStatus === "pending_review"
-      ? copy.pendingBody
-      : copy.archivedBody;
-  const fallbackNotice = isJapanese && metadata.is_fallback
-    ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F\u307E\u3060\u65E5\u672C\u8A9E\u7248\u304C\u306A\u3044\u305F\u3081\u3001\u672C\u6587\u306F\u82F1\u8A9E\u30BD\u30FC\u30B9\u3092\u8868\u793A\u3057\u3066\u3044\u307E\u3059\u3002\u4E3B\u8981UI\u3068\u5C0E\u7DDA\u306F\u65E5\u672C\u8A9E\u5316\u3057\u3066\u3044\u307E\u3059\u3002"
-    : null;
+        ? copy.pendingBody
+        : copy.archivedBody;
+  const fallbackNotice =
+    isJapanese && metadata.is_fallback
+      ? "\u3053\u306E\u30DA\u30FC\u30B8\u306F\u307E\u3060\u65E5\u672C\u8A9E\u7248\u304C\u306A\u3044\u305F\u3081\u3001\u672C\u6587\u306F\u82F1\u8A9E\u30BD\u30FC\u30B9\u3092\u8868\u793A\u3057\u3066\u3044\u307E\u3059\u3002\u4E3B\u8981UI\u3068\u5C0E\u7DDA\u306F\u65E5\u672C\u8A9E\u5316\u3057\u3066\u3044\u307E\u3059\u3002"
+      : null;
 
   return (
     <div className="bg-white dark:bg-black min-h-screen py-12 transition-colors duration-300">
@@ -267,7 +308,10 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                       {metadata.title}
                     </h1>
                     {verified && (
-                      <BadgeCheck className="h-6 w-6 sm:h-8 sm:w-8 text-blue-500" aria-label="Verified Tool" />
+                      <BadgeCheck
+                        className="h-6 w-6 sm:h-8 sm:w-8 text-blue-500"
+                        aria-label="Verified Tool"
+                      />
                     )}
                   </div>
                   <span className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
@@ -285,11 +329,14 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                       <Calendar className="h-4 w-4" />
                       <span>
                         {t("lastUpdated")}:{" "}
-                        {new Date(last_updated).toLocaleDateString(locale === "ja" ? "ja-JP" : "en-US", {
-                          year: "numeric",
-                          month: "long",
-                          day: "numeric",
-                        })}
+                        {new Date(last_updated).toLocaleDateString(
+                          locale === "ja" ? "ja-JP" : "en-US",
+                          {
+                            year: "numeric",
+                            month: "long",
+                            day: "numeric",
+                          },
+                        )}
                       </span>
                     </div>
                   )}
@@ -325,18 +372,34 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                   </p>
                   <div className="mt-4 flex flex-wrap gap-3 text-xs font-medium text-zinc-500 dark:text-zinc-400">
                     <span className="rounded-full bg-white px-3 py-1 ring-1 ring-blue-100 dark:bg-zinc-950 dark:ring-blue-900/50">
-                      {copy.syncLastChecked}: {syncSummary.lastCheckedAt ? new Date(syncSummary.lastCheckedAt).toLocaleDateString(locale === "ja" ? "ja-JP" : "en-US", {
-                        year: "numeric",
-                        month: "short",
-                        day: "numeric",
-                      }) : copy.unknown}
+                      {copy.syncLastChecked}:{" "}
+                      {syncSummary.lastCheckedAt
+                        ? new Date(
+                            syncSummary.lastCheckedAt,
+                          ).toLocaleDateString(
+                            locale === "ja" ? "ja-JP" : "en-US",
+                            {
+                              year: "numeric",
+                              month: "short",
+                              day: "numeric",
+                            },
+                          )
+                        : copy.unknown}
                     </span>
                     <span className="rounded-full bg-white px-3 py-1 ring-1 ring-blue-100 dark:bg-zinc-950 dark:ring-blue-900/50">
-                      {copy.syncLastChanged}: {syncSummary.lastChangedAt ? new Date(syncSummary.lastChangedAt).toLocaleDateString(locale === "ja" ? "ja-JP" : "en-US", {
-                        year: "numeric",
-                        month: "short",
-                        day: "numeric",
-                      }) : copy.unknown}
+                      {copy.syncLastChanged}:{" "}
+                      {syncSummary.lastChangedAt
+                        ? new Date(
+                            syncSummary.lastChangedAt,
+                          ).toLocaleDateString(
+                            locale === "ja" ? "ja-JP" : "en-US",
+                            {
+                              year: "numeric",
+                              month: "short",
+                              day: "numeric",
+                            },
+                          )
+                        : copy.unknown}
                     </span>
                   </div>
                   {syncSummary.highlights.length > 0 && (
@@ -357,8 +420,8 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                   editorialStatus === "reviewed"
                     ? "border-green-200 bg-green-50 dark:border-green-500/20 dark:bg-green-500/10"
                     : editorialStatus === "pending_review"
-                    ? "border-amber-200 bg-amber-50 dark:border-amber-500/20 dark:bg-amber-500/10"
-                    : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950"
+                      ? "border-amber-200 bg-amber-50 dark:border-amber-500/20 dark:bg-amber-500/10"
+                      : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950",
                 )}
               >
                 <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
@@ -375,17 +438,29 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
               <div className="rounded-3xl border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-800 dark:bg-zinc-950">
                 <dl className="space-y-4 text-sm">
                   <div className="flex items-start justify-between gap-4">
-                    <dt className="text-zinc-500 dark:text-zinc-400">{copy.status}</dt>
-                    <dd className="font-semibold text-zinc-900 dark:text-zinc-100">{statusLabel}</dd>
-                  </div>
-                  <div className="flex items-start justify-between gap-4">
-                    <dt className="text-zinc-500 dark:text-zinc-400">{copy.pricing}</dt>
-                    <dd className="text-right font-semibold text-zinc-900 dark:text-zinc-100">
-                      {formatPricingLabel(locale, metadata.price, metadata.pricing)}
+                    <dt className="text-zinc-500 dark:text-zinc-400">
+                      {copy.status}
+                    </dt>
+                    <dd className="font-semibold text-zinc-900 dark:text-zinc-100">
+                      {statusLabel}
                     </dd>
                   </div>
                   <div className="flex items-start justify-between gap-4">
-                    <dt className="text-zinc-500 dark:text-zinc-400">{copy.platform}</dt>
+                    <dt className="text-zinc-500 dark:text-zinc-400">
+                      {copy.pricing}
+                    </dt>
+                    <dd className="text-right font-semibold text-zinc-900 dark:text-zinc-100">
+                      {formatPricingLabel(
+                        locale,
+                        metadata.price,
+                        metadata.pricing,
+                      )}
+                    </dd>
+                  </div>
+                  <div className="flex items-start justify-between gap-4">
+                    <dt className="text-zinc-500 dark:text-zinc-400">
+                      {copy.platform}
+                    </dt>
                     <dd className="text-right font-semibold text-zinc-900 dark:text-zinc-100">
                       {metadata.platform?.join(", ") || copy.unknown}
                     </dd>
@@ -395,17 +470,19 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                   {compareHref && (
                     <Link
                       href={compareHref}
-                      className="inline-flex items-center rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                      className="group inline-flex items-center rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                     >
                       {copy.compareCategory}
+                      <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                     </Link>
                   )}
                   {categorySlug && (
                     <Link
                       href={`/category/${categorySlug}`}
-                      className="inline-flex items-center rounded-full border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
+                      className="group inline-flex items-center rounded-full border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-900 transition-colors hover:border-zinc-400 hover:bg-white dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
                     >
                       {copy.browseCategory}
+                      <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                     </Link>
                   )}
                 </div>
@@ -456,10 +533,16 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                     {t("affiliateDisclaimer")}
                   </p>
                   <div className="mt-2 flex flex-wrap gap-3 text-xs font-medium">
-                    <Link href="/affiliate-disclosure" className="text-blue-600 hover:underline dark:text-blue-400">
+                    <Link
+                      href="/affiliate-disclosure"
+                      className="text-blue-600 hover:underline dark:text-blue-400"
+                    >
                       {copy.disclosureLink}
                     </Link>
-                    <Link href="/editorial-policy" className="text-blue-600 hover:underline dark:text-blue-400">
+                    <Link
+                      href="/editorial-policy"
+                      className="text-blue-600 hover:underline dark:text-blue-400"
+                    >
                       {copy.policyLink}
                     </Link>
                   </div>
@@ -484,7 +567,9 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
               <ShareButtons
                 url={url}
                 title={metadata.title}
-                twitterText={tShare("twitterShareTool", { toolName: metadata.title })}
+                twitterText={tShare("twitterShareTool", {
+                  toolName: metadata.title,
+                })}
               />
             </div>
           </div>


### PR DESCRIPTION
This PR makes a small, trustworthy UI enhancement to the call-to-action (CTA) buttons on the Category and Tool pages. By adding an `ArrowRight` icon from `lucide-react` with a subtle hover translation effect, the buttons for comparing categories and browsing tools are made more visually distinct and interactive, which can help improve click-through rates. The change is isolated to UI components and relies only on Tailwind CSS utility classes and Lucide icons.

---
*PR created automatically by Jules for task [12768409551632631831](https://jules.google.com/task/12768409551632631831) started by @yuga-hashimoto*