### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior

### DIFF
--- a/src/app/api/partner-inquiry/route.ts
+++ b/src/app/api/partner-inquiry/route.ts
@@ -47,27 +47,26 @@ export async function POST(request: NextRequest) {
       locale: body.locale || "en",
     });
 
-    try {
-      await appendPartnerInquiry({
-        inquiryType: record.inquiryType,
-        companyName: record.companyName,
-        contactName: record.contactName,
-        email: record.email,
-        websiteUrl: record.websiteUrl,
-        packageInterest: record.packageInterest,
-        monthlyBudget: record.monthlyBudget,
-        message: record.message,
-        locale: record.locale,
-      });
-      console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
-    } catch (sheetError) {
-      const errorMsg = sheetError instanceof Error ? sheetError.message : String(sheetError);
-      if (errorMsg.includes('not configured')) {
-        console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
-      } else {
+    if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+      try {
+        await appendPartnerInquiry({
+          inquiryType: record.inquiryType,
+          companyName: record.companyName,
+          contactName: record.contactName,
+          email: record.email,
+          websiteUrl: record.websiteUrl,
+          packageInterest: record.packageInterest,
+          monthlyBudget: record.monthlyBudget,
+          message: record.message,
+          locale: record.locale,
+        });
+        console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
+      } catch (sheetError) {
         console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
         console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
       }
+    } else {
+      console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
     }
 
     return NextResponse.json({

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -75,12 +75,17 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      try {
-        await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
-        console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
-      } catch (sheetError) {
-        console.warn('Google Sheets append failed or not configured, falling back to local logging:', sheetError);
-        console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
+      if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+        try {
+          await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
+          console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        } catch (sheetError) {
+          console.warn('Google Sheets append failed, falling back to local logging:', sheetError);
+          console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
+          console.log('Submission data:', { name, url, description, category, pricing_model, price });
+        }
+      } else {
+        console.warn(`[TOOL SUBMISSION FALLBACK] Google Sheets not configured. New submission: ${name} (${url}) at ${new Date().toISOString()}`);
         console.log('Submission data:', { name, url, description, category, pricing_model, price });
       }
       


### PR DESCRIPTION
This PR fixes an operational issue where the `partner-inquiry` and `submit` API routes were relying on catching error strings to determine if the Google Sheets integration was configured.

It updates the fallback behavior to explicitly check if `process.env.GOOGLE_SERVICE_ACCOUNT_JSON` is present before attempting the append operation, which ensures clearer error logging and prevents misleading warnings during unconfigured local or testing environments. This matches the established pattern already used in `subscribe` and `leads`.

---
*PR created automatically by Jules for task [6239004262243390498](https://jules.google.com/task/6239004262243390498) started by @yuga-hashimoto*