### PR TITLE
🧭 Trust Builder: Improve schema/metadata for paid tools

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === "free" || metadata.pricing === "freemium") {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === "free" || metadata.pricing === "freemium")) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
This PR improves the structured data schema to increase editorial trust and transparency.

Previously, `generateProductSchema` and `generateToolSchema` indiscriminately included an `offers` schema object with a price of `$0` ("price": "0") for every tool, even for paid tools. This created deceptive, overclaiming schema metadata.

This PR fixes this by conditionally outputting the `offers` schema block containing the "0" price only if the tool's `metadata.pricing` property is explicitly marked as `"free"` or `"freemium"`.

---
*PR created automatically by Jules for task [8848139185655249234](https://jules.google.com/task/8848139185655249234) started by @yuga-hashimoto*