### PR TITLE
🧭 Trust Builder: Improve schema pricing transparency

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -96,15 +96,18 @@ export function generateProductSchema(tool: Tool) {
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
     "mpn": metadata.slug,
-    "offers": {
+  };
+
+  if (metadata.pricing === "free" || metadata.pricing === "freemium") {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,7 +158,7 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.affiliate_link && (metadata.pricing === "free" || metadata.pricing === "freemium")) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",


### PR DESCRIPTION
## Summary
As a Trust Builder, I identified an issue where the site's Schema.org output (both Product and Tool schemas) universally advertised a `$0` offer for all tools with an affiliate link, regardless of their actual pricing model. This could cause search engines to display deceptive `$0` rich snippets for paid AI tools, harming user trust.

## Changes
- Updated `generateProductSchema` and `generateToolSchema` in `src/lib/schema.ts`.
- Conditioned the inclusion of the `Offer` object (which hardcodes `price: "0"`) on `metadata.pricing === "free" || metadata.pricing === "freemium"`.
- This ensures only genuinely free or freemium tools are advertised as `$0` in structured data, improving transparency and SEO quality.

---
*PR created automatically by Jules for task [11112599958224638095](https://jules.google.com/task/11112599958224638095) started by @yuga-hashimoto*