### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getCategoryLandingContent } from "@/lib/category-landing";
 import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
+import { ArrowRight } from "lucide-react";
 
 export async function generateStaticParams() {
   return Object.keys(CATEGORY_MAPPINGS).map((slug) => ({
@@ -233,9 +234,10 @@ export default async function CategoryPage({
                 {compareHref && (
                   <Link
                     href={compareHref}
-                    className="inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    className="group inline-flex items-center rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     {copy.compareCta}
+                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
                 <Link

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -9,6 +9,7 @@ import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
+import { ArrowRight } from "lucide-react";
 
 export async function generateMetadata({
   params,
@@ -127,8 +128,9 @@ export default async function ComparePage({
               >
                 <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">{preset.title}</h3>
                 <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">{preset.description}</p>
-                <div className="mt-5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                <div className="group mt-5 inline-flex items-center text-sm font-semibold text-blue-600 dark:text-blue-400">
                   {copy.presetCta}
+                  <ArrowRight className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </div>
               </Link>
             ))}

--- a/src/app/[locale]/tools/[slug]/page.tsx
+++ b/src/app/[locale]/tools/[slug]/page.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkDirective from "remark-directive";
 import { remarkYoutube } from "@/lib/remark-youtube";
-import { ExternalLink, BadgeCheck, Calendar } from "lucide-react";
+import { ExternalLink, BadgeCheck, Calendar, ArrowRight } from "lucide-react";
 import { Metadata } from "next";
 import { Rating } from "@/components/Rating";
 import { ArticleCard } from "@/components/ArticleCard";
@@ -395,9 +395,10 @@ export default async function ToolPage({ params }: { params: Promise<{ slug: str
                   {compareHref && (
                     <Link
                       href={compareHref}
-                      className="inline-flex items-center rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                      className="group inline-flex items-center rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                     >
                       {copy.compareCategory}
+                      <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                     </Link>
                   )}
                   {categorySlug && (


### PR DESCRIPTION
This PR improves the clarity and interactivity of the comparison CTAs across the site.

It adds an `ArrowRight` icon from `lucide-react` to the 'Compare this category' and 'Compare this set' buttons on the tool, category, and comparison pages. It also updates the button classes to use `inline-flex` and applies a subtle hover translation effect (`group-hover:translate-x-1`) to the arrow to make the CTAs look more clickable and draw user attention to them.

---
*PR created automatically by Jules for task [13805818357008743092](https://jules.google.com/task/13805818357008743092) started by @yuga-hashimoto*