### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -2,6 +2,7 @@ import { getAllTools } from "@/lib/tools";
 import { CompareView } from "@/components/CompareView";
 import { Metadata } from "next";
 import { Link } from "@/i18n/routing";
+import { ArrowRight } from "lucide-react";
 import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { getTranslations } from "next-intl/server";
 import { generateBreadcrumbSchema } from "@/lib/schema";
@@ -123,12 +124,13 @@ export default async function ComparePage({
               <Link
                 key={preset.title}
                 href={preset.href}
-                className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                className="group rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
               >
                 <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">{preset.title}</h3>
                 <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">{preset.description}</p>
-                <div className="mt-5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                <div className="mt-5 flex items-center text-sm font-semibold text-blue-600 dark:text-blue-400">
                   {copy.presetCta}
+                  <ArrowRight className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </div>
               </Link>
             ))}

--- a/src/components/CompareView.tsx
+++ b/src/components/CompareView.tsx
@@ -3,7 +3,7 @@
 import { Link } from "@/i18n/routing";
 import { ToolMetadata } from "@/lib/tools";
 import { useCompare } from "@/context/CompareContext";
-import { AlertTriangle, BadgeCheck, Check, ExternalLink, X } from "lucide-react";
+import { AlertTriangle, ArrowRight, BadgeCheck, Check, ExternalLink, X } from "lucide-react";
 import { Rating } from "@/components/Rating";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
 
@@ -104,9 +104,10 @@ export function CompareView({ tools, locale }: CompareViewProps) {
         </p>
         <Link
           href="/"
-          className="mt-8 rounded-full bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          className="mt-8 inline-flex items-center rounded-full bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
         >
           {copy.browseTools}
+          <ArrowRight className="ml-2 h-4 w-4" />
         </Link>
       </div>
     );
@@ -136,8 +137,9 @@ export function CompareView({ tools, locale }: CompareViewProps) {
                 {tool.category}
               </div>
               <div className="mt-4">
-                <Link href={`/tools/${tool.slug}`} className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400">
+                <Link href={`/tools/${tool.slug}`} className="group inline-flex items-center text-sm font-medium text-blue-600 hover:underline dark:text-blue-400">
                   {copy.viewDetails}
+                  <ArrowRight className="ml-1 h-3.5 w-3.5 transition-transform group-hover:translate-x-1" />
                 </Link>
               </div>
             </div>
@@ -240,7 +242,7 @@ export function CompareView({ tools, locale }: CompareViewProps) {
                 toolSlug={tool.slug}
                 toolName={tool.title}
                 position="compare_table"
-                className="inline-flex items-center justify-center rounded-md bg-green-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+                className="inline-flex w-full items-center justify-center rounded-md bg-green-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
               >
                 {copy.visitSite}
                 <ExternalLink className="ml-2 h-4 w-4" />


### PR DESCRIPTION
**Issue:** The comparison page CTAs ("Compare this set", "Browse tools", "View details") lacked strong visual affordances to indicate clickability, and the "Visit Site" CTA in the comparison table did not span the full cell width, reducing the click target area.

**Changes:**
1. Added the `ArrowRight` icon from `lucide-react` to multiple text-based CTAs on the compare page.
2. Implemented hover-state animations (`transition-transform group-hover:translate-x-1`) for the preset buttons and inline text links to create a more responsive, interactive feel.
3. Expanded the "Visit Site" affiliate link button inside the comparison table to span full width (`w-full`), significantly increasing the hit target area for mobile and desktop users.

These small, non-spammy UX improvements are designed to increase click-through rates and overall funnel clarity.

---
*PR created automatically by Jules for task [5247632709205591489](https://jules.google.com/task/5247632709205591489) started by @yuga-hashimoto*