### PR TITLE
💰 Revenue Optimizer: Improve affiliate disclosure visibility

### DIFF
--- a/src/app/[locale]/category/[slug]/page.tsx
+++ b/src/app/[locale]/category/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs, BreadcrumbItem } from "@/components/Breadcrumbs";
 import { HeroSearchBar } from "@/components/HeroSearchBar";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateLinkButton } from "@/components/AffiliateLinkButton";
+import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
 import {
   generateBreadcrumbSchema,
   generateCollectionPageSchema,
@@ -275,6 +276,11 @@ export default async function CategoryPage({
             forceShow={true}
             className="mb-10"
           />
+
+          <div className="mb-10 max-w-3xl">
+            <AffiliateDisclaimer variant="compact" />
+          </div>
+
           <div className="max-w-3xl">
             <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
               {copy.compareTableTitle}


### PR DESCRIPTION
This PR adds the `AffiliateDisclaimer` component to the category landing pages (`src/app/[locale]/category/[slug]/page.tsx`), right above the comparison table.

This improves the visibility of affiliate disclosures on category hubs, which are a primary entry point featuring many tools and affiliate links. It uses the `compact` variant to align with existing usages on other pages like the comparison page.

---
*PR created automatically by Jules for task [16698919534593510071](https://jules.google.com/task/16698919534593510071) started by @yuga-hashimoto*