### PR TITLE
🧭 Trust Builder: Improve schema/metadata pricing transparency

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -95,16 +95,19 @@ export function generateProductSchema(tool: Tool) {
     "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
     "url": `${SITE_URL}/tools/${metadata.slug}`,
     "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    "mpn": metadata.slug
+  };
+
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
+    schema.offers = {
       "@type": "Offer",
       "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock",
       "validFrom": metadata.last_updated || new Date().toISOString()
-    }
-  };
+    };
+  }
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
@@ -155,11 +158,11 @@ export function generateToolSchema(tool: Tool) {
     schema.featureList = metadata.pros.join(", ");
   }
 
-  if (metadata.affiliate_link) {
+  if (metadata.pricing === 'free' || metadata.pricing === 'freemium') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",
-      "url": metadata.affiliate_link,
+      "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
       "price": "0",
       "priceCurrency": "USD",
       "availability": "https://schema.org/InStock"


### PR DESCRIPTION
This PR addresses a structured data issue where the zero-dollar (`price: "0"`) `Offer` schema was being unconditionally added to `Product` and `SoftwareApplication` JSON-LD outputs for all tools. 

To prevent deceptive rich snippets and overclaiming that paid tools are free, this logic has been updated to conditionally output the `Offer` object only when a tool is explicitly marked with `pricing === 'free'` or `pricing === 'freemium'`. If `affiliate_link` is absent but the condition is met, it safely falls back to the local tool page URL. This improves overall editorial trust and SEO compliance.

---
*PR created automatically by Jules for task [45390227399956712](https://jules.google.com/task/45390227399956712) started by @yuga-hashimoto*