### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/compare/[comparisonSlug]/page.tsx
+++ b/src/app/[locale]/compare/[comparisonSlug]/page.tsx
@@ -7,9 +7,16 @@ import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { getAllTools, ToolMetadata } from "@/lib/tools";
 import { generateBreadcrumbSchema, generateFAQSchema } from "@/lib/schema";
-import { getComparePresetBySlug, parseComparisonSlug } from "@/lib/compare-pages";
-import { getEditorialToolStatus, isReviewPendingToolSlug } from "@/lib/editorial";
+import {
+  getComparePresetBySlug,
+  parseComparisonSlug,
+} from "@/lib/compare-pages";
+import {
+  getEditorialToolStatus,
+  isReviewPendingToolSlug,
+} from "@/lib/editorial";
 import { Link } from "@/i18n/routing";
+import { ExternalLink } from "lucide-react";
 
 interface PageParams {
   locale: string;
@@ -18,27 +25,32 @@ interface PageParams {
 
 function formatPricing(
   locale: string,
-  tool: Pick<ToolMetadata, "price" | "pricing">
+  tool: Pick<ToolMetadata, "price" | "pricing">,
 ): string {
   if (tool.price) {
     return tool.price;
   }
 
-  const labels = locale === "ja"
-    ? {
-        free: "無料",
-        freemium: "フリーミアム",
-        paid: "有料",
-        contact: "要問い合わせ",
-      }
-    : {
-        free: "Free",
-        freemium: "Freemium",
-        paid: "Paid",
-        contact: "Contact sales",
-      };
+  const labels =
+    locale === "ja"
+      ? {
+          free: "無料",
+          freemium: "フリーミアム",
+          paid: "有料",
+          contact: "要問い合わせ",
+        }
+      : {
+          free: "Free",
+          freemium: "Freemium",
+          paid: "Paid",
+          contact: "Contact sales",
+        };
 
-  return tool.pricing ? labels[tool.pricing] : locale === "ja" ? "Not listed" : "Not listed";
+  return tool.pricing
+    ? labels[tool.pricing]
+    : locale === "ja"
+      ? "Not listed"
+      : "Not listed";
 }
 
 function formatUpdated(locale: string, value?: string): string {
@@ -58,7 +70,10 @@ function formatUpdated(locale: string, value?: string): string {
   });
 }
 
-async function resolveTools(locale: string, comparisonSlug: string): Promise<ToolMetadata[]> {
+async function resolveTools(
+  locale: string,
+  comparisonSlug: string,
+): Promise<ToolMetadata[]> {
   const allTools = await getAllTools(locale);
   const slugs = parseComparisonSlug(comparisonSlug);
   const tools = slugs
@@ -74,7 +89,7 @@ export async function generateStaticParams() {
     COMPARE_PRESETS.map((preset) => ({
       locale,
       comparisonSlug: preset.slug,
-    }))
+    })),
   );
 }
 
@@ -257,19 +272,31 @@ export default async function CompareTemplatePage({
                     status === "reviewed"
                       ? copy.reviewed
                       : status === "pending_review"
-                      ? copy.pending
-                      : copy.archived;
+                        ? copy.pending
+                        : copy.archived;
 
                   return (
                     <tr key={tool.slug}>
                       <td className="px-6 py-5">
-                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">{tool.title}</div>
-                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{tool.description}</div>
+                        <div className="font-semibold text-zinc-900 dark:text-zinc-100">
+                          {tool.title}
+                        </div>
+                        <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                          {tool.description}
+                        </div>
                       </td>
-                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">{tool.rating}</td>
-                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">{formatPricing(locale, tool)}</td>
-                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">{statusLabel}</td>
-                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">{formatUpdated(locale, tool.last_updated)}</td>
+                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">
+                        {tool.rating}
+                      </td>
+                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">
+                        {formatPricing(locale, tool)}
+                      </td>
+                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">
+                        {statusLabel}
+                      </td>
+                      <td className="px-6 py-5 text-sm text-zinc-700 dark:text-zinc-300">
+                        {formatUpdated(locale, tool.last_updated)}
+                      </td>
                       <td className="px-6 py-5">
                         <div className="flex flex-wrap items-center justify-end gap-4">
                           <Link
@@ -286,6 +313,7 @@ export default async function CompareTemplatePage({
                             className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500"
                           >
                             {copy.visit}
+                            <ExternalLink className="ml-1 h-4 w-4" />
                           </AffiliateLinkButton>
                         </div>
                       </td>
@@ -308,8 +336,12 @@ export default async function CompareTemplatePage({
                   key={faq.question}
                   className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
                 >
-                  <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{faq.question}</h3>
-                  <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">{faq.answer}</p>
+                  <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                    {faq.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                    {faq.answer}
+                  </p>
                 </div>
               ))}
             </div>

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -9,6 +9,7 @@ import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
+import { ArrowRight } from "lucide-react";
 
 export async function generateMetadata({
   params,
@@ -19,7 +20,9 @@ export async function generateMetadata({
   const isJapanese = locale === "ja";
 
   return {
-    title: isJapanese ? "AIツール比較ハブ | AI Tool Navigator" : "Compare AI Tools | AI Tool Navigator",
+    title: isJapanese
+      ? "AIツール比較ハブ | AI Tool Navigator"
+      : "Compare AI Tools | AI Tool Navigator",
     description: isJapanese
       ? "主要AIツールを横並びで比較。価格、検証状況、長所短所を確認し、最適なAIソリューションを見つけましょう。"
       : "Compare leading AI tools side-by-side. Evaluate features, pricing, review status, and pros/cons to find the best AI solution for your workflow.",
@@ -36,7 +39,9 @@ export default async function ComparePage({
 }) {
   const { locale } = await params;
   const isJapanese = locale === "ja";
-  const tools = filterToolList(await getAllTools(locale)).sort(sortToolsForEditorialLists);
+  const tools = filterToolList(await getAllTools(locale)).sort(
+    sortToolsForEditorialLists,
+  );
   const tBreadcrumbs = await getTranslations("Breadcrumbs");
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -123,12 +128,17 @@ export default async function ComparePage({
               <Link
                 key={preset.title}
                 href={preset.href}
-                className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                className="group rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
               >
-                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">{preset.title}</h3>
-                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">{preset.description}</p>
-                <div className="mt-5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">
+                  {preset.title}
+                </h3>
+                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                  {preset.description}
+                </p>
+                <div className="mt-5 flex items-center text-sm font-semibold text-blue-600 dark:text-blue-400">
                   {copy.presetCta}
+                  <ArrowRight className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </div>
               </Link>
             ))}


### PR DESCRIPTION
This PR improves the Click-Through Rate (CTR) and clarity of CTAs on the comparison pages by doing two things:
1. Adds an `ExternalLink` icon to the outbound affiliate "Visit site" buttons on comparison detail pages to clearly indicate they lead to an external site.
2. Adds an `ArrowRight` icon with a hover transition to the internal comparison preset links on the comparison index page to make them feel more actionable.

---
*PR created automatically by Jules for task [17372872327379409699](https://jules.google.com/task/17372872327379409699) started by @yuga-hashimoto*