### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior in forms

### DIFF
--- a/src/app/api/partner-inquiry/route.ts
+++ b/src/app/api/partner-inquiry/route.ts
@@ -47,27 +47,26 @@ export async function POST(request: NextRequest) {
       locale: body.locale || "en",
     });
 
-    try {
-      await appendPartnerInquiry({
-        inquiryType: record.inquiryType,
-        companyName: record.companyName,
-        contactName: record.contactName,
-        email: record.email,
-        websiteUrl: record.websiteUrl,
-        packageInterest: record.packageInterest,
-        monthlyBudget: record.monthlyBudget,
-        message: record.message,
-        locale: record.locale,
-      });
-      console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
-    } catch (sheetError) {
-      const errorMsg = sheetError instanceof Error ? sheetError.message : String(sheetError);
-      if (errorMsg.includes('not configured')) {
-        console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
-      } else {
+    if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+      try {
+        await appendPartnerInquiry({
+          inquiryType: record.inquiryType,
+          companyName: record.companyName,
+          contactName: record.contactName,
+          email: record.email,
+          websiteUrl: record.websiteUrl,
+          packageInterest: record.packageInterest,
+          monthlyBudget: record.monthlyBudget,
+          message: record.message,
+          locale: record.locale,
+        });
+        console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
+      } catch (sheetError) {
         console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
         console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
       }
+    } else {
+      console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
     }
 
     return NextResponse.json({

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -75,12 +75,17 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      try {
-        await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
-        console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
-      } catch (sheetError) {
-        console.warn('Google Sheets append failed or not configured, falling back to local logging:', sheetError);
-        console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
+      if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+        try {
+          await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
+          console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        } catch (sheetError) {
+          console.warn('Google Sheets append failed or not configured, falling back to local logging:', sheetError);
+          console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
+          console.log('Submission data:', { name, url, description, category, pricing_model, price });
+        }
+      } else {
+        console.warn(`[TOOL SUBMISSION FALLBACK] Google Sheets not configured. New submission: ${name} (${url}) at ${new Date().toISOString()}`);
         console.log('Submission data:', { name, url, description, category, pricing_model, price });
       }
       


### PR DESCRIPTION
Explicitly check for the `GOOGLE_SERVICE_ACCOUNT_JSON` environment variable before executing the append operation in form submissions (`partner-inquiry` and `submit` API routes) to gracefully handle missing credentials and avoid relying on catching error strings. If it's missing, gracefully skip the execution and provide clear console fallback logging.

---
*PR created automatically by Jules for task [11842627914336396150](https://jules.google.com/task/11842627914336396150) started by @yuga-hashimoto*