### PR TITLE
💰 Revenue Optimizer: Improve comparison page CTA clarity

### DIFF
--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -9,6 +9,7 @@ import { filterToolList, sortToolsForEditorialLists } from "@/lib/editorial";
 import { getComparisonHref } from "@/lib/compare-pages";
 import { DynamicAdUnit } from "@/components/DynamicAdUnit";
 import { AffiliateDisclaimer } from "@/components/AffiliateDisclaimer";
+import { ArrowRight } from "lucide-react";
 
 export async function generateMetadata({
   params,
@@ -19,7 +20,9 @@ export async function generateMetadata({
   const isJapanese = locale === "ja";
 
   return {
-    title: isJapanese ? "AIツール比較ハブ | AI Tool Navigator" : "Compare AI Tools | AI Tool Navigator",
+    title: isJapanese
+      ? "AIツール比較ハブ | AI Tool Navigator"
+      : "Compare AI Tools | AI Tool Navigator",
     description: isJapanese
       ? "主要AIツールを横並びで比較。価格、検証状況、長所短所を確認し、最適なAIソリューションを見つけましょう。"
       : "Compare leading AI tools side-by-side. Evaluate features, pricing, review status, and pros/cons to find the best AI solution for your workflow.",
@@ -36,7 +39,9 @@ export default async function ComparePage({
 }) {
   const { locale } = await params;
   const isJapanese = locale === "ja";
-  const tools = filterToolList(await getAllTools(locale)).sort(sortToolsForEditorialLists);
+  const tools = filterToolList(await getAllTools(locale)).sort(
+    sortToolsForEditorialLists,
+  );
   const tBreadcrumbs = await getTranslations("Breadcrumbs");
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -123,12 +128,17 @@ export default async function ComparePage({
               <Link
                 key={preset.title}
                 href={preset.href}
-                className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                className="group rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
               >
-                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">{preset.title}</h3>
-                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">{preset.description}</p>
-                <div className="mt-5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+                <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-3">
+                  {preset.title}
+                </h3>
+                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                  {preset.description}
+                </p>
+                <div className="mt-5 inline-flex items-center text-sm font-semibold text-blue-600 transition-transform group-hover:translate-x-1 dark:text-blue-400">
                   {copy.presetCta}
+                  <ArrowRight className="ml-1 h-4 w-4" />
                 </div>
               </Link>
             ))}


### PR DESCRIPTION
This PR addresses the "comparison page CTA clarity" focus area by adding a clear `ArrowRight` icon and a horizontal translation hover effect (`group-hover:translate-x-1`) to the "Compare this set" links on the `/compare` page. This visually distinguishes the Call-to-Action and creates a cohesive UI pattern consistent with the homepage and category hub pages.

---
*PR created automatically by Jules for task [10565338180274081465](https://jules.google.com/task/10565338180274081465) started by @yuga-hashimoto*