### PR TITLE
🧭 Trust Builder: Improve schema/metadata

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -4,29 +4,29 @@ import { BreadcrumbItem } from "@/components/Breadcrumbs";
 
 const APPLICATION_CATEGORY_MAP: Record<string, string> = {
   "Video Generation": "MultimediaApplication",
-  "Writing": "BusinessApplication",
-  "Copywriting": "BusinessApplication",
-  "Code": "DeveloperApplication",
-  "Coding": "DeveloperApplication",
+  Writing: "BusinessApplication",
+  Copywriting: "BusinessApplication",
+  Code: "DeveloperApplication",
+  Coding: "DeveloperApplication",
   "Coding Agent": "DeveloperApplication",
   "Coding Assistant": "DeveloperApplication",
-  "LLM": "BusinessApplication",
-  "Search": "UtilitiesApplication",
+  LLM: "BusinessApplication",
+  Search: "UtilitiesApplication",
   "AI Comparisons": "UtilitiesApplication",
   "AI Coworker": "BusinessApplication",
-  "Automation": "BusinessApplication",
+  Automation: "BusinessApplication",
   "Business Automation": "BusinessApplication",
-  "Comparison": "UtilitiesApplication",
+  Comparison: "UtilitiesApplication",
   "LLM/Chatbot": "CommunicationApplication",
-  "Marketing": "BusinessApplication",
+  Marketing: "BusinessApplication",
   "Real Estate": "BusinessApplication",
-  "Security": "SecurityApplication",
+  Security: "SecurityApplication",
   "Text-to-Speech": "MultimediaApplication",
   "Upcoming LLM": "BusinessApplication",
   "Website Builder": "DesignApplication",
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://ai-tools-nav.com';
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://ai-tools-nav.com";
 
 // =====================================================
 // ORGANIZATION SCHEMA
@@ -35,22 +35,23 @@ export function generateOrganizationSchema() {
   return {
     "@context": "https://schema.org",
     "@type": "Organization",
-    "name": "AI Tool Navigator",
-    "url": SITE_URL,
-    "logo": `${SITE_URL}/logo.png`,
-    "description": "Discover and compare the best AI tools for writing, coding, image generation, and more. Find the perfect AI solution for your workflow.",
-    "foundingDate": "2024",
-    "sameAs": [
+    name: "AI Tool Navigator",
+    url: SITE_URL,
+    logo: `${SITE_URL}/logo.png`,
+    description:
+      "Discover and compare the best AI tools for writing, coding, image generation, and more. Find the perfect AI solution for your workflow.",
+    foundingDate: "2024",
+    sameAs: [
       "https://twitter.com/aitoolnav",
       "https://github.com/aitoolnav",
-      "https://linkedin.com/company/aitoolnav"
+      "https://linkedin.com/company/aitoolnav",
     ],
-    "contactPoint": {
+    contactPoint: {
       "@type": "ContactPoint",
-      "contactType": "customer support",
-      "url": `${SITE_URL}/support`,
-      "availableLanguage": ["English", "Japanese"]
-    }
+      contactType: "customer support",
+      url: `${SITE_URL}/support`,
+      availableLanguage: ["English", "Japanese"],
+    },
   };
 }
 
@@ -61,17 +62,18 @@ export function generateLocalBusinessSchema() {
   return {
     "@context": "https://schema.org",
     "@type": "WebSite",
-    "name": "AI Tool Navigator",
-    "url": SITE_URL,
-    "description": "Discover and compare the best AI tools for writing, coding, image generation, and more. Find the perfect AI solution for your workflow.",
-    "potentialAction": {
+    name: "AI Tool Navigator",
+    url: SITE_URL,
+    description:
+      "Discover and compare the best AI tools for writing, coding, image generation, and more. Find the perfect AI solution for your workflow.",
+    potentialAction: {
       "@type": "SearchAction",
-      "target": {
+      target: {
         "@type": "EntryPoint",
-        "urlTemplate": `${SITE_URL}/?search={search_term_string}`
+        urlTemplate: `${SITE_URL}/?search={search_term_string}`,
       },
-      "query-input": "required name=search_term_string"
-    }
+      "query-input": "required name=search_term_string",
+    },
   };
 }
 
@@ -85,35 +87,43 @@ export function generateProductSchema(tool: Tool) {
   const schema: any = {
     "@context": "https://schema.org",
     "@type": "Product",
-    "name": metadata.title,
-    "description": metadata.description,
-    "brand": {
+    name: metadata.title,
+    description: metadata.description,
+    brand: {
       "@type": "Brand",
-      "name": metadata.title
+      name: metadata.title,
     },
-    "category": metadata.category,
-    "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
-    "url": `${SITE_URL}/tools/${metadata.slug}`,
-    "sku": `tool-${metadata.slug}`,
-    "mpn": metadata.slug,
-    "offers": {
+    category: metadata.category,
+    image: metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
+    url: `${SITE_URL}/tools/${metadata.slug}`,
+    sku: `tool-${metadata.slug}`,
+    mpn: metadata.slug,
+    offers: {
       "@type": "Offer",
-      "url": metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
-      "priceCurrency": "USD",
-      "price": "0",
-      "availability": "https://schema.org/InStock",
-      "validFrom": metadata.last_updated || new Date().toISOString()
-    }
+      url: metadata.affiliate_link || `${SITE_URL}/tools/${metadata.slug}`,
+      priceCurrency: "USD",
+      ...(!metadata.pricing ||
+      metadata.pricing === "free" ||
+      metadata.pricing === "freemium"
+        ? { price: "0" }
+        : metadata.price
+          ? { price: metadata.price }
+          : {}),
+      availability: "https://schema.org/InStock",
+      validFrom: metadata.last_updated || new Date().toISOString(),
+    },
   };
 
   if (metadata.rating) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
     schema.aggregateRating = {
       "@type": "AggregateRating",
-      "ratingValue": metadata.rating,
-      "reviewCount": metadata.rating_breakdown ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0) : 1,
-      "bestRating": bestRating,
-      "worstRating": "1"
+      ratingValue: metadata.rating,
+      reviewCount: metadata.rating_breakdown
+        ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0)
+        : 1,
+      bestRating: bestRating,
+      worstRating: "1",
     };
   }
 
@@ -139,16 +149,19 @@ export function generateToolSchema(tool: Tool) {
   const schema: any = {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
-    "name": metadata.title,
-    "description": metadata.description,
-    "applicationCategory": APPLICATION_CATEGORY_MAP[metadata.category] || metadata.category || "Application",
-    "operatingSystem": "Web, iOS, Android",
-    "permissions": "internet-access",
-    "version": "1.0",
-    "softwareRequirements": "modern-web-browser",
-    "image": metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
-    "url": `${SITE_URL}/tools/${metadata.slug}`,
-    "dateModified": metadata.last_updated || new Date().toISOString()
+    name: metadata.title,
+    description: metadata.description,
+    applicationCategory:
+      APPLICATION_CATEGORY_MAP[metadata.category] ||
+      metadata.category ||
+      "Application",
+    operatingSystem: "Web, iOS, Android",
+    permissions: "internet-access",
+    version: "1.0",
+    softwareRequirements: "modern-web-browser",
+    image: metadata.image ? `${SITE_URL}${metadata.image}` : undefined,
+    url: `${SITE_URL}/tools/${metadata.slug}`,
+    dateModified: metadata.last_updated || new Date().toISOString(),
   };
 
   if (metadata.pros && metadata.pros.length > 0) {
@@ -159,10 +172,16 @@ export function generateToolSchema(tool: Tool) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const offer: any = {
       "@type": "Offer",
-      "url": metadata.affiliate_link,
-      "price": "0",
-      "priceCurrency": "USD",
-      "availability": "https://schema.org/InStock"
+      url: metadata.affiliate_link,
+      ...(!metadata.pricing ||
+      metadata.pricing === "free" ||
+      metadata.pricing === "freemium"
+        ? { price: "0" }
+        : metadata.price
+          ? { price: metadata.price }
+          : {}),
+      priceCurrency: "USD",
+      availability: "https://schema.org/InStock",
     };
     if (metadata.discount) {
       offer.description = metadata.discount;
@@ -174,26 +193,28 @@ export function generateToolSchema(tool: Tool) {
     const bestRating = metadata.rating > 5 ? "10" : "5";
     schema.aggregateRating = {
       "@type": "AggregateRating",
-      "ratingValue": metadata.rating,
-      "ratingCount": metadata.rating_breakdown ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0) : 1,
-      "bestRating": bestRating,
-      "worstRating": "1"
+      ratingValue: metadata.rating,
+      ratingCount: metadata.rating_breakdown
+        ? Object.values(metadata.rating_breakdown).reduce((a, b) => a + b, 0)
+        : 1,
+      bestRating: bestRating,
+      worstRating: "1",
     };
 
     schema.review = {
       "@type": "Review",
-      "reviewRating": {
+      reviewRating: {
         "@type": "Rating",
-        "ratingValue": metadata.rating,
-        "bestRating": bestRating,
-        "worstRating": "1"
+        ratingValue: metadata.rating,
+        bestRating: bestRating,
+        worstRating: "1",
       },
-      "author": {
+      author: {
         "@type": "Organization",
-        "name": "AI Tool Navigator"
+        name: "AI Tool Navigator",
       },
-      "reviewBody": metadata.description,
-      "datePublished": metadata.last_updated || new Date().toISOString()
+      reviewBody: metadata.description,
+      datePublished: metadata.last_updated || new Date().toISOString(),
     };
   }
 
@@ -210,39 +231,41 @@ export function generateBlogPostSchema(post: Post, url: string) {
   const schema: any = {
     "@context": "https://schema.org",
     "@type": "Article",
-    "headline": metadata.title,
-    "description": metadata.excerpt,
-    "datePublished": metadata.date,
-    "dateModified": metadata.date,
-    "author": [{
-      "@type": "Person",
-      "name": metadata.author,
-      "url": `${SITE_URL}/about`
-    }],
-    "publisher": {
+    headline: metadata.title,
+    description: metadata.excerpt,
+    datePublished: metadata.date,
+    dateModified: metadata.date,
+    author: [
+      {
+        "@type": "Person",
+        name: metadata.author,
+        url: `${SITE_URL}/about`,
+      },
+    ],
+    publisher: {
       "@type": "Organization",
-      "name": "AI Tool Navigator",
-      "logo": {
+      name: "AI Tool Navigator",
+      logo: {
         "@type": "ImageObject",
-        "url": `${SITE_URL}/logo.png`
-      }
+        url: `${SITE_URL}/logo.png`,
+      },
     },
-    "url": url,
-    "mainEntityOfPage": {
+    url: url,
+    mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": url
+      "@id": url,
     },
-    "articleSection": "Blog",
-    "inLanguage": metadata.locale || "en",
-    "wordCount": metadata.readingTime ? metadata.readingTime * 200 : 1000
+    articleSection: "Blog",
+    inLanguage: metadata.locale || "en",
+    wordCount: metadata.readingTime ? metadata.readingTime * 200 : 1000,
   };
 
   if (metadata.image) {
     schema.image = {
       "@type": "ImageObject",
-      "url": `${SITE_URL}${metadata.image}`,
-      "width": "1200",
-      "height": "630"
+      url: `${SITE_URL}${metadata.image}`,
+      width: "1200",
+      height: "630",
     };
   }
 
@@ -273,39 +296,41 @@ export function generateArticleSchema(article: {
   const schema: any = {
     "@context": "https://schema.org",
     "@type": "Article",
-    "headline": article.title,
-    "description": article.description,
-    "datePublished": article.datePublished,
-    "dateModified": article.dateModified || article.datePublished,
-    "author": [{
-      "@type": "Person",
-      "name": article.author,
-      "url": `${SITE_URL}/about`
-    }],
-    "publisher": {
+    headline: article.title,
+    description: article.description,
+    datePublished: article.datePublished,
+    dateModified: article.dateModified || article.datePublished,
+    author: [
+      {
+        "@type": "Person",
+        name: article.author,
+        url: `${SITE_URL}/about`,
+      },
+    ],
+    publisher: {
       "@type": "Organization",
-      "name": "AI Tool Navigator",
-      "logo": {
+      name: "AI Tool Navigator",
+      logo: {
         "@type": "ImageObject",
-        "url": `${SITE_URL}/logo.png`
-      }
+        url: `${SITE_URL}/logo.png`,
+      },
     },
-    "url": article.url,
-    "mainEntityOfPage": {
+    url: article.url,
+    mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": article.url
+      "@id": article.url,
     },
-    "articleSection": "Blog",
-    "inLanguage": article.locale || "en",
-    "wordCount": article.readingTime ? article.readingTime * 200 : 1000
+    articleSection: "Blog",
+    inLanguage: article.locale || "en",
+    wordCount: article.readingTime ? article.readingTime * 200 : 1000,
   };
 
   if (article.image) {
     schema.image = {
       "@type": "ImageObject",
-      "url": `${SITE_URL}${article.image}`,
-      "width": "1200",
-      "height": "630"
+      url: `${SITE_URL}${article.image}`,
+      width: "1200",
+      height: "630",
     };
   }
 
@@ -320,22 +345,24 @@ export function generateArticleSchema(article: {
 // =====================================================
 // FAQ SCHEMA
 // =====================================================
-export function generateFAQSchema(faqs: Array<{ question: string; answer: string }>) {
+export function generateFAQSchema(
+  faqs: Array<{ question: string; answer: string }>,
+) {
   const items = faqs.map((faq, index) => ({
     "@type": "Question",
-    "name": faq.question,
-    "acceptedAnswer": {
+    name: faq.question,
+    acceptedAnswer: {
       "@type": "Answer",
-      "text": faq.answer,
-      "upvoteCount": 1
+      text: faq.answer,
+      upvoteCount: 1,
     },
-    "position": index + 1
+    position: index + 1,
   }));
 
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    "mainEntity": items
+    mainEntity: items,
   };
 }
 
@@ -354,16 +381,16 @@ export function generateHowToSchema(howTo: {
   const schema: any = {
     "@context": "https://schema.org",
     "@type": "HowTo",
-    "name": howTo.title,
-    "description": howTo.description,
-    "totalTime": howTo.totalTime || "PT15M",
-    "step": howTo.steps.map((step, index) => ({
+    name: howTo.title,
+    description: howTo.description,
+    totalTime: howTo.totalTime || "PT15M",
+    step: howTo.steps.map((step, index) => ({
       "@type": "HowToStep",
-      "position": index + 1,
-      "name": step.name,
-      "text": step.text,
-      "url": step.url ? `${SITE_URL}${step.url}` : undefined
-    }))
+      position: index + 1,
+      name: step.name,
+      text: step.text,
+      url: step.url ? `${SITE_URL}${step.url}` : undefined,
+    })),
   };
 
   if (howTo.image) {
@@ -373,11 +400,13 @@ export function generateHowToSchema(howTo: {
   if (howTo.videoUrl) {
     schema.video = {
       "@type": "VideoObject",
-      "name": howTo.title,
-      "description": howTo.description,
-      "thumbnailUrl": [howTo.image ? `${SITE_URL}${howTo.image}` : `${SITE_URL}/og-image.png`],
-      "contentUrl": howTo.videoUrl,
-      "embedUrl": howTo.videoUrl.replace('watch?v=', 'embed/')
+      name: howTo.title,
+      description: howTo.description,
+      thumbnailUrl: [
+        howTo.image ? `${SITE_URL}${howTo.image}` : `${SITE_URL}/og-image.png`,
+      ],
+      contentUrl: howTo.videoUrl,
+      embedUrl: howTo.videoUrl.replace("watch?v=", "embed/"),
     };
   }
 
@@ -399,27 +428,27 @@ export function generateReviewSchema(review: {
   return {
     "@context": "https://schema.org",
     "@type": "Review",
-    "itemReviewed": {
+    itemReviewed: {
       "@type": "Product",
-      "name": review.itemReviewed,
-      "image": review.image ? `${SITE_URL}${review.image}` : undefined
+      name: review.itemReviewed,
+      image: review.image ? `${SITE_URL}${review.image}` : undefined,
     },
-    "reviewRating": {
+    reviewRating: {
       "@type": "Rating",
-      "ratingValue": review.ratingValue,
-      "bestRating": review.bestRating || "5",
-      "worstRating": "1"
+      ratingValue: review.ratingValue,
+      bestRating: review.bestRating || "5",
+      worstRating: "1",
     },
-    "author": {
+    author: {
       "@type": "Person",
-      "name": review.author
+      name: review.author,
     },
-    "reviewBody": review.reviewBody,
-    "datePublished": review.datePublished || new Date().toISOString(),
-    "publisher": {
+    reviewBody: review.reviewBody,
+    datePublished: review.datePublished || new Date().toISOString(),
+    publisher: {
       "@type": "Organization",
-      "name": "AI Tool Navigator"
-    }
+      name: "AI Tool Navigator",
+    },
   };
 }
 
@@ -440,39 +469,42 @@ export function generateAggregateReviewSchema(item: {
   return {
     "@context": "https://schema.org",
     "@type": "Product",
-    "name": item.name,
-    "description": item.description,
-    "image": item.image ? `${SITE_URL}${item.image}` : undefined,
-    "aggregateRating": {
+    name: item.name,
+    description: item.description,
+    image: item.image ? `${SITE_URL}${item.image}` : undefined,
+    aggregateRating: {
       "@type": "AggregateRating",
-      "ratingValue": item.aggregateRating.ratingValue,
-      "reviewCount": item.aggregateRating.reviewCount,
-      "bestRating": item.aggregateRating.bestRating || "5",
-      "worstRating": item.aggregateRating.worstRating || "1"
-    }
+      ratingValue: item.aggregateRating.ratingValue,
+      reviewCount: item.aggregateRating.reviewCount,
+      bestRating: item.aggregateRating.bestRating || "5",
+      worstRating: item.aggregateRating.worstRating || "1",
+    },
   };
 }
 
 // =====================================================
 // BREADCRUMB SCHEMA (existing)
 // =====================================================
-export function generateBreadcrumbSchema(items: BreadcrumbItem[], locale: string) {
+export function generateBreadcrumbSchema(
+  items: BreadcrumbItem[],
+  locale: string,
+) {
   const itemListElement = items.map((item, index) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const schemaItem: any = {
       "@type": "ListItem",
-      "position": index + 1,
-      "name": item.label
+      position: index + 1,
+      name: item.label,
     };
 
     if (item.href) {
       // If href is present, construct full URL
-      const path = item.href === '/' ? '' : item.href;
+      const path = item.href === "/" ? "" : item.href;
       // Ensure path starts with / if not empty
-      const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+      const normalizedPath = path.startsWith("/") ? path : `/${path}`;
       // Note: next-intl routing typically handles locale prefixing in Link component,
       // but for schema URL we need absolute URL including locale.
-      schemaItem.item = `${SITE_URL}/${locale}${normalizedPath === '/' ? '' : normalizedPath}`;
+      schemaItem.item = `${SITE_URL}/${locale}${normalizedPath === "/" ? "" : normalizedPath}`;
     }
 
     return schemaItem;
@@ -481,7 +513,7 @@ export function generateBreadcrumbSchema(items: BreadcrumbItem[], locale: string
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
-    "itemListElement": itemListElement
+    itemListElement: itemListElement,
   };
 }
 
@@ -492,36 +524,36 @@ export function generatePlatformSchema(description: string, locale: string) {
   return {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    "name": "AI Tool Navigator",
-    "url": `${SITE_URL}/${locale}`,
-    "description": description,
-    "applicationCategory": "SearchApplication",
-    "applicationSubCategory": "AI Tool Directory",
-    "operatingSystem": "Web Browser",
-    "offers": {
+    name: "AI Tool Navigator",
+    url: `${SITE_URL}/${locale}`,
+    description: description,
+    applicationCategory: "SearchApplication",
+    applicationSubCategory: "AI Tool Directory",
+    operatingSystem: "Web Browser",
+    offers: {
       "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD",
-      "availability": "https://schema.org/InStock"
+      price: "0",
+      priceCurrency: "USD",
+      availability: "https://schema.org/InStock",
     },
-    "potentialAction": {
+    potentialAction: {
       "@type": "SearchAction",
-      "target": {
+      target: {
         "@type": "EntryPoint",
-        "urlTemplate": `${SITE_URL}/${locale}?search={search_term_string}`,
-        "actionPlatform": [
+        urlTemplate: `${SITE_URL}/${locale}?search={search_term_string}`,
+        actionPlatform: [
           "https://schema.org/DesktopWebPlatform",
-          "https://schema.org/MobileWebPlatform"
-        ]
+          "https://schema.org/MobileWebPlatform",
+        ],
       },
-      "query-input": "required name=search_term_string"
+      "query-input": "required name=search_term_string",
     },
-    "softwareVersion": "1.0.0",
-    "author": {
+    softwareVersion: "1.0.0",
+    author: {
       "@type": "Organization",
-      "name": "AI Tool Navigator",
-      "url": SITE_URL
-    }
+      name: "AI Tool Navigator",
+      url: SITE_URL,
+    },
   };
 }
 
@@ -539,18 +571,18 @@ export function generateWebPageSchema(page: {
   return {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": page.title,
-    "description": page.description,
-    "url": page.url,
-    "datePublished": page.datePublished || new Date().toISOString(),
-    "dateModified": page.dateModified || new Date().toISOString(),
-    "image": page.image ? `${SITE_URL}${page.image}` : `${SITE_URL}/og-image.png`,
-    "inLanguage": "en",
-    "isPartOf": {
+    name: page.title,
+    description: page.description,
+    url: page.url,
+    datePublished: page.datePublished || new Date().toISOString(),
+    dateModified: page.dateModified || new Date().toISOString(),
+    image: page.image ? `${SITE_URL}${page.image}` : `${SITE_URL}/og-image.png`,
+    inLanguage: "en",
+    isPartOf: {
       "@type": "WebSite",
-      "name": "AI Tool Navigator",
-      "url": SITE_URL
-    }
+      name: "AI Tool Navigator",
+      url: SITE_URL,
+    },
   };
 }
 
@@ -567,92 +599,99 @@ export function generateCollectionPageSchema(collection: {
   return {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    "name": collection.name,
-    "description": collection.description,
-    "url": collection.url,
-    "image": collection.image ? `${SITE_URL}${collection.image}` : `${SITE_URL}/og-image.png`,
-    "mainEntity": {
+    name: collection.name,
+    description: collection.description,
+    url: collection.url,
+    image: collection.image
+      ? `${SITE_URL}${collection.image}`
+      : `${SITE_URL}/og-image.png`,
+    mainEntity: {
       "@type": "ItemList",
-      "numberOfItems": collection.itemCount,
-      "itemListOrder": "https://schema.org/ItemListUnordered"
+      numberOfItems: collection.itemCount,
+      itemListOrder: "https://schema.org/ItemListUnordered",
     },
-    "isPartOf": {
+    isPartOf: {
       "@type": "WebSite",
-      "name": "AI Tool Navigator",
-      "url": SITE_URL
-    }
+      name: "AI Tool Navigator",
+      url: SITE_URL,
+    },
   };
 }
 
 // =====================================================
 // NAVIGATION MENU SCHEMA
 // =====================================================
-export function generateSiteNavigationSchema(navItems: Array<{ label: string; url: string }>) {
+export function generateSiteNavigationSchema(
+  navItems: Array<{ label: string; url: string }>,
+) {
   return {
     "@context": "https://schema.org",
     "@type": "SiteNavigationElement",
-    "name": "Main Navigation",
-    "url": SITE_URL,
-    "hasMenuSection": navItems.map((item, index) => ({
+    name: "Main Navigation",
+    url: SITE_URL,
+    hasMenuSection: navItems.map((item, index) => ({
       "@type": "MenuSection",
-      "name": item.label,
-      "url": `${SITE_URL}${item.url}`,
-      "position": index + 1
-    }))
+      name: item.label,
+      url: `${SITE_URL}${item.url}`,
+      position: index + 1,
+    })),
   };
 }
 
 // =====================================================
 // SITELINK SEARCH BOX SCHEMA
 // =====================================================
-export function generateSearchBoxSchema(locale: string = 'en') {
+export function generateSearchBoxSchema(locale: string = "en") {
   return {
     "@context": "https://schema.org",
     "@type": "WebSite",
-    "name": "AI Tool Navigator",
-    "url": `${SITE_URL}/${locale}`,
-    "potentialAction": {
+    name: "AI Tool Navigator",
+    url: `${SITE_URL}/${locale}`,
+    potentialAction: {
       "@type": "SearchAction",
-      "target": {
+      target: {
         "@type": "EntryPoint",
-        "urlTemplate": `${SITE_URL}/${locale}?search={search_term_string}`,
-        "actionPlatform": [
+        urlTemplate: `${SITE_URL}/${locale}?search={search_term_string}`,
+        actionPlatform: [
           "https://schema.org/DesktopWebPlatform",
-          "https://schema.org/MobileWebPlatform"
-        ]
+          "https://schema.org/MobileWebPlatform",
+        ],
       },
-      "query-input": "required name=search_term_string"
-    }
+      "query-input": "required name=search_term_string",
+    },
   };
 }
 
 // =====================================================
 // COMPARISON TABLE SCHEMA
 // =====================================================
-export function generateComparisonSchema(products: Array<{
-  name: string;
-  description: string;
-  url: string;
-  image?: string;
-  rating?: number;
-  price?: string;
-}>) {
+export function generateComparisonSchema(
+  products: Array<{
+    name: string;
+    description: string;
+    url: string;
+    image?: string;
+    rating?: number;
+    price?: string;
+  }>,
+) {
   return {
     "@context": "https://schema.org",
     "@type": "Table",
-    "about": "AI Tools Comparison",
-    "description": "Comparison of AI tools including features, pricing, and ratings",
-    "associatedMedia": {
+    about: "AI Tools Comparison",
+    description:
+      "Comparison of AI tools including features, pricing, and ratings",
+    associatedMedia: {
       "@type": "MediaObject",
-      "name": "AI Tools Comparison"
+      name: "AI Tools Comparison",
     },
-    "hasPart": products.map((product, index) => ({
+    hasPart: products.map((product, index) => ({
       "@type": "WebPage",
-      "name": product.name,
-      "description": product.description,
-      "url": product.url,
-      "position": index + 1
-    }))
+      name: product.name,
+      description: product.description,
+      url: product.url,
+      position: index + 1,
+    })),
   };
 }
 
@@ -669,20 +708,22 @@ export function generateSponsoredContentSchema(content: {
   return {
     "@context": "https://schema.org",
     "@type": "Article",
-    "name": content.name,
-    "description": content.description,
-    "url": content.url,
-    "image": content.image ? `${SITE_URL}${content.image}` : `${SITE_URL}/og-image.png`,
-    "publisher": {
+    name: content.name,
+    description: content.description,
+    url: content.url,
+    image: content.image
+      ? `${SITE_URL}${content.image}`
+      : `${SITE_URL}/og-image.png`,
+    publisher: {
       "@type": "Organization",
-      "name": content.sponsorName
+      name: content.sponsorName,
     },
-    "isNativeAdvertising": true,
-    "isPartOf": {
+    isNativeAdvertising: true,
+    isPartOf: {
       "@type": "WebSite",
-      "name": "AI Tool Navigator",
-      "url": SITE_URL
-    }
+      name: "AI Tool Navigator",
+      url: SITE_URL,
+    },
   };
 }
 
@@ -702,31 +743,35 @@ export function generateNewsArticleSchema(article: {
   return {
     "@context": "https://schema.org",
     "@type": "NewsArticle",
-    "headline": article.headline,
-    "description": article.description,
-    "url": article.url,
-    "datePublished": article.datePublished,
-    "dateModified": article.dateModified || article.datePublished,
-    "author": [{
-      "@type": "Person",
-      "name": article.author
-    }],
-    "publisher": {
+    headline: article.headline,
+    description: article.description,
+    url: article.url,
+    datePublished: article.datePublished,
+    dateModified: article.dateModified || article.datePublished,
+    author: [
+      {
+        "@type": "Person",
+        name: article.author,
+      },
+    ],
+    publisher: {
       "@type": "Organization",
-      "name": article.publisher || "AI Tool Navigator",
-      "logo": {
+      name: article.publisher || "AI Tool Navigator",
+      logo: {
         "@type": "ImageObject",
-        "url": `${SITE_URL}/logo.png`
-      }
+        url: `${SITE_URL}/logo.png`,
+      },
     },
-    "image": article.image ? `${SITE_URL}${article.image}` : `${SITE_URL}/og-image.png`,
-    "articleSection": "News",
-    "inLanguage": "en",
-    "isPartOf": {
+    image: article.image
+      ? `${SITE_URL}${article.image}`
+      : `${SITE_URL}/og-image.png`,
+    articleSection: "News",
+    inLanguage: "en",
+    isPartOf: {
       "@type": "WebSite",
-      "name": "AI Tool Navigator",
-      "url": SITE_URL
-    }
+      name: "AI Tool Navigator",
+      url: SITE_URL,
+    },
   };
 }
 
@@ -746,8 +791,8 @@ export function generatePersonSchema(person: {
   const schema: any = {
     "@context": "https://schema.org",
     "@type": "Person",
-    "name": person.name,
-    "url": person.url || SITE_URL
+    name: person.name,
+    url: person.url || SITE_URL,
   };
 
   if (person.jobTitle) {
@@ -757,8 +802,8 @@ export function generatePersonSchema(person: {
   if (person.worksFor) {
     schema.worksFor = {
       "@type": "Organization",
-      "name": person.worksFor,
-      "url": SITE_URL
+      name: person.worksFor,
+      url: SITE_URL,
     };
   }
 
@@ -784,21 +829,20 @@ export function generateAboutPageSchema() {
   return {
     "@context": "https://schema.org",
     "@type": "AboutPage",
-    "name": "About AI Tool Navigator",
-    "description": "AI Tool Navigator helps you discover and compare the best AI tools for your workflow.",
-    "url": `${SITE_URL}/about`,
-    "mainEntity": {
+    name: "About AI Tool Navigator",
+    description:
+      "AI Tool Navigator helps you discover and compare the best AI tools for your workflow.",
+    url: `${SITE_URL}/about`,
+    mainEntity: {
       "@type": "Organization",
-      "name": "AI Tool Navigator",
-      "url": SITE_URL,
-      "logo": `${SITE_URL}/logo.png`,
-      "description": "Discover and compare the best AI tools for writing, coding, image generation, and more.",
-      "foundingDate": "2024",
-      "sameAs": [
-        "https://twitter.com/aitoolnav",
-        "https://github.com/aitoolnav"
-      ]
-    }
+      name: "AI Tool Navigator",
+      url: SITE_URL,
+      logo: `${SITE_URL}/logo.png`,
+      description:
+        "Discover and compare the best AI tools for writing, coding, image generation, and more.",
+      foundingDate: "2024",
+      sameAs: ["https://twitter.com/aitoolnav", "https://github.com/aitoolnav"],
+    },
   };
 }
 
@@ -810,35 +854,56 @@ export function generateAboutPageSchema() {
  * Generates all applicable schemas for a given page type
  * Useful for comprehensive schema coverage
  */
-export function generatePageSchemas(pageType: string, data: Record<string, unknown>, locale: string = 'en') {
+export function generatePageSchemas(
+  pageType: string,
+  data: Record<string, unknown>,
+  locale: string = "en",
+) {
   switch (pageType) {
-    case 'homepage':
+    case "homepage":
       return [
         generateOrganizationSchema(),
         generateSearchBoxSchema(locale),
-        generatePlatformSchema(typeof data.description === 'string' ? data.description : '', locale)
+        generatePlatformSchema(
+          typeof data.description === "string" ? data.description : "",
+          locale,
+        ),
       ];
-    case 'tool':
+    case "tool":
       return [
         generateToolSchema(data.tool as Tool),
         generateProductSchema(data.tool as Tool),
-        generateBreadcrumbSchema(data.breadcrumbItems as BreadcrumbItem[], locale)
+        generateBreadcrumbSchema(
+          data.breadcrumbItems as BreadcrumbItem[],
+          locale,
+        ),
       ];
-    case 'blog':
+    case "blog":
       return [
         generateBlogPostSchema(data.post as Post, data.url as string),
-        generateBreadcrumbSchema(data.breadcrumbItems as BreadcrumbItem[], locale)
+        generateBreadcrumbSchema(
+          data.breadcrumbItems as BreadcrumbItem[],
+          locale,
+        ),
       ];
-    case 'category':
+    case "category":
       return [
-        generateCollectionPageSchema(data.collection as { name: string; description: string; url: string; itemCount: number; image?: string }),
-        generateBreadcrumbSchema(data.breadcrumbItems as BreadcrumbItem[], locale)
+        generateCollectionPageSchema(
+          data.collection as {
+            name: string;
+            description: string;
+            url: string;
+            itemCount: number;
+            image?: string;
+          },
+        ),
+        generateBreadcrumbSchema(
+          data.breadcrumbItems as BreadcrumbItem[],
+          locale,
+        ),
       ];
-    case 'about':
-      return [
-        generateAboutPageSchema(),
-        generateOrganizationSchema()
-      ];
+    case "about":
+      return [generateAboutPageSchema(), generateOrganizationSchema()];
     default:
       return [];
   }
@@ -851,17 +916,17 @@ export function generatePageSchemas(pageType: string, data: Record<string, unkno
 export function validateSchema(schema: Record<string, unknown>): string[] {
   const errors: string[] = [];
 
-  if (!schema['@context']) {
-    errors.push('Missing @context');
+  if (!schema["@context"]) {
+    errors.push("Missing @context");
   }
 
-  if (!schema['@type']) {
-    errors.push('Missing @type');
+  if (!schema["@type"]) {
+    errors.push("Missing @type");
   }
 
   // Check for @context validity
-  if (schema['@context'] && schema['@context'] !== 'https://schema.org') {
-    errors.push('Invalid @context value');
+  if (schema["@context"] && schema["@context"] !== "https://schema.org") {
+    errors.push("Invalid @context value");
   }
 
   return errors;


### PR DESCRIPTION
This pull request improves the schema generated by `generateProductSchema` and `generateToolSchema` to fix a major transparency and editorial trust issue. Previously, the `price` property in the `Offer` object of tools was unconditionally hardcoded to `"0"`, regardless of the actual pricing model. This falsely advertises paid tools as free in search engine results and creates misleading structured data. The fix conditionally sets the price to `"0"` only if `metadata.pricing` is "free", "freemium", or undefined. If the tool is paid but the price is omitted in its metadata, the property is simply excluded, which is valid for Schema.org formats. This ensures tools are appropriately represented in search results without engaging in overclaiming.

---
*PR created automatically by Jules for task [11138413408034288266](https://jules.google.com/task/11138413408034288266) started by @yuga-hashimoto*