### PR TITLE
🛠️ Ops Guard: Fix Google Sheets fallback behavior

### DIFF
--- a/src/app/api/partner-inquiry/route.ts
+++ b/src/app/api/partner-inquiry/route.ts
@@ -28,7 +28,10 @@ export async function POST(request: NextRequest) {
       !body.websiteUrl ||
       !body.message
     ) {
-      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 },
+      );
     }
 
     if (!isValidEmail(body.email)) {
@@ -48,25 +51,44 @@ export async function POST(request: NextRequest) {
     });
 
     try {
-      await appendPartnerInquiry({
-        inquiryType: record.inquiryType,
-        companyName: record.companyName,
-        contactName: record.contactName,
-        email: record.email,
-        websiteUrl: record.websiteUrl,
-        packageInterest: record.packageInterest,
-        monthlyBudget: record.monthlyBudget,
-        message: record.message,
-        locale: record.locale,
-      });
-      console.log(`[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`);
-    } catch (sheetError) {
-      const errorMsg = sheetError instanceof Error ? sheetError.message : String(sheetError);
-      if (errorMsg.includes('not configured')) {
-        console.warn(`[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`);
+      if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+        await appendPartnerInquiry({
+          inquiryType: record.inquiryType,
+          companyName: record.companyName,
+          contactName: record.contactName,
+          email: record.email,
+          websiteUrl: record.websiteUrl,
+          packageInterest: record.packageInterest,
+          monthlyBudget: record.monthlyBudget,
+          message: record.message,
+          locale: record.locale,
+        });
+        console.log(
+          `[PARTNER INQUIRY] New inquiry appended to Google Sheets: ${record.companyName} (${record.email})`,
+        );
       } else {
-        console.warn('Google Sheets append failed, falling back to local DB record only:', sheetError);
-        console.log(`[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`);
+        console.warn(
+          "GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.",
+        );
+        console.log(
+          `[PARTNER INQUIRY FALLBACK] Inquiry recorded locally: ${record.companyName} (${record.email})`,
+        );
+      }
+    } catch (sheetError) {
+      const errorMsg =
+        sheetError instanceof Error ? sheetError.message : String(sheetError);
+      if (errorMsg.includes("not configured")) {
+        console.warn(
+          `[PARTNER INQUIRY FALLBACK] Google Sheets not configured. Inquiry recorded locally: ${record.companyName} (${record.email})`,
+        );
+      } else {
+        console.warn(
+          "Google Sheets append failed, falling back to local DB record only:",
+          sheetError,
+        );
+        console.log(
+          `[PARTNER INQUIRY FALLBACK] New inquiry recorded locally: ${record.companyName} (${record.email})`,
+        );
       }
     }
 
@@ -76,6 +98,9 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error("[Partner Inquiry API] Failed:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -1,31 +1,39 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { appendToolSubmission, ToolSubmissionData } from '@/lib/google-sheets';
-import { securityCheck, checkFormSecurity, createRateLimitHeaders } from '@/lib/security';
+import { NextRequest, NextResponse } from "next/server";
+import { appendToolSubmission, ToolSubmissionData } from "@/lib/google-sheets";
+import {
+  securityCheck,
+  checkFormSecurity,
+  createRateLimitHeaders,
+} from "@/lib/security";
 // import { validateHoneypot, HONEYPOT_FIELDS } from '@/lib/security/honeypot';
-import { logFormSubmission } from '@/lib/security/audit-log';
-import { getClientIP } from '@/lib/security/bot-detection';
-import { trackRequest } from '@/lib/security/anomaly-detection';
+import { logFormSubmission } from "@/lib/security/audit-log";
+import { getClientIP } from "@/lib/security/bot-detection";
+import { trackRequest } from "@/lib/security/anomaly-detection";
 // import { setApiCompressionHeaders } from '@/lib/compression/headers';
 
 export async function POST(request: NextRequest) {
   const ip = getClientIP(request);
-  const userAgent = request.headers.get('user-agent') || '';
+  const userAgent = request.headers.get("user-agent") || "";
   const path = request.nextUrl.pathname;
 
   try {
     // Security check
     const securityResult = await securityCheck(request);
-    
+
     if (!securityResult.allowed) {
-      if (securityResult.challenge === 'block') {
+      if (securityResult.challenge === "block") {
         return NextResponse.json(
-          { error: 'Forbidden', message: securityResult.reason },
-          { status: 403 }
+          { error: "Forbidden", message: securityResult.reason },
+          { status: 403 },
         );
       }
       return NextResponse.json(
-        { error: 'Verification Required', message: securityResult.reason, requiresCaptcha: true },
-        { status: 429 }
+        {
+          error: "Verification Required",
+          message: securityResult.reason,
+          requiresCaptcha: true,
+        },
+        { status: 429 },
       );
     }
 
@@ -38,7 +46,7 @@ export async function POST(request: NextRequest) {
     Object.entries(body).forEach(([key, value]) => {
       if (value) formData.set(key, String(value));
     });
-    
+
     // Honeypot validation temporarily disabled - module missing
     // const honeypotResult = validateHoneypot(formData, {
     //   websiteField: HONEYPOT_FIELDS.WEBSITE,
@@ -58,10 +66,10 @@ export async function POST(request: NextRequest) {
 
     // Basic validation
     if (!name || !url || !description || !category || !pricing_model) {
-      await trackRequest(ip, path, 'POST', 400, userAgent);
+      await trackRequest(ip, path, "POST", 400, userAgent);
       return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 }
+        { error: "Missing required fields" },
+        { status: 400 },
       );
     }
 
@@ -69,45 +77,80 @@ export async function POST(request: NextRequest) {
     const formSecurity = await checkFormSecurity(request, formData);
     if (!formSecurity.allowed) {
       return NextResponse.json(
-        { error: 'Too many submissions', message: formSecurity.reason },
-        { status: 429 }
+        { error: "Too many submissions", message: formSecurity.reason },
+        { status: 429 },
       );
     }
 
     try {
       try {
-        await appendToolSubmission({ name, url, description, category, pricing_model, price: price || '' });
-        console.log(`[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`);
+        if (process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
+          await appendToolSubmission({
+            name,
+            url,
+            description,
+            category,
+            pricing_model,
+            price: price || "",
+          });
+          console.log(
+            `[TOOL SUBMISSION] New submission appended to Google Sheets: ${name} (${url}) at ${new Date().toISOString()}`,
+          );
+        } else {
+          console.warn(
+            "GOOGLE_SERVICE_ACCOUNT_JSON not set, skipping Google Sheets append.",
+          );
+          console.log(
+            `[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`,
+          );
+          console.log("Submission data:", {
+            name,
+            url,
+            description,
+            category,
+            pricing_model,
+            price,
+          });
+        }
       } catch (sheetError) {
-        console.warn('Google Sheets append failed or not configured, falling back to local logging:', sheetError);
-        console.log(`[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`);
-        console.log('Submission data:', { name, url, description, category, pricing_model, price });
+        console.warn(
+          "Google Sheets append failed, falling back to local logging:",
+          sheetError,
+        );
+        console.log(
+          `[TOOL SUBMISSION FALLBACK] New submission: ${name} (${url}) at ${new Date().toISOString()}`,
+        );
+        console.log("Submission data:", {
+          name,
+          url,
+          description,
+          category,
+          pricing_model,
+          price,
+        });
       }
-      
-      await trackRequest(ip, path, 'POST', 200, userAgent);
-      await logFormSubmission(ip, path, 'tool_submission', false, userAgent);
+
+      await trackRequest(ip, path, "POST", 200, userAgent);
+      await logFormSubmission(ip, path, "tool_submission", false, userAgent);
 
       return NextResponse.json(
-        { message: 'Tool submitted successfully' },
-        { 
+        { message: "Tool submitted successfully" },
+        {
           status: 200,
           headers: createRateLimitHeaders(4, Date.now() + 60000),
-        }
+        },
       );
     } catch (error) {
-      console.error('Tool submission error:', error);
-      await trackRequest(ip, path, 'POST', 500, userAgent);
+      console.error("Tool submission error:", error);
+      await trackRequest(ip, path, "POST", 500, userAgent);
       return NextResponse.json(
-        { error: 'Internal server error' },
-        { status: 500 }
+        { error: "Internal server error" },
+        { status: 500 },
       );
     }
   } catch (error) {
-    console.error('Request processing error:', error);
-    await trackRequest(ip, path, 'POST', 400, userAgent);
-    return NextResponse.json(
-      { error: 'Bad Request' },
-      { status: 400 }
-    );
+    console.error("Request processing error:", error);
+    await trackRequest(ip, path, "POST", 400, userAgent);
+    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
   }
 }


### PR DESCRIPTION
This PR fixes a small operational issue affecting tracking, form handling, content sync, or admin visibility by specifically improving the Google Sheets fallback behavior in the API routes.

Previously, the `src/app/api/submit/route.ts` and `src/app/api/partner-inquiry/route.ts` endpoints naively attempted to append data to Google Sheets even if the required credentials (`process.env.GOOGLE_SERVICE_ACCOUNT_JSON`) were entirely missing. This relied on the catch block to handle the missing configuration, which could lead to slower responses and messier logs.

This change introduces an explicit check for the environment variable *before* attempting the API call. If the variable is absent, it gracefully falls back to local logging and provides a clear `[TOOL SUBMISSION FALLBACK]` or `[PARTNER INQUIRY FALLBACK]` console message. This improves admin visibility and operational clarity by clearly distinguishing between unconfigured environments and actual runtime API failures.

---
*PR created automatically by Jules for task [15228102066428948715](https://jules.google.com/task/15228102066428948715) started by @yuga-hashimoto*